### PR TITLE
fix: set exit code to 1 if there are vulnerabilities

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,4 +101,6 @@ func main() {
 		file,
 		knownVulnerabilitiesCount,
 	))
+
+	os.Exit(1)
 }


### PR DESCRIPTION
I've gone with 1 for now, but I might make it more specific in the future.

Closes #16 