### PR TITLE
pref: preallocate `packages` array in composer lock parser

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ keep the codebase healthy, which can be run with:
 make lint
 ```
 
-Currently, there are _6_ unresolved linting errors which are yet to be handled -
+Currently, there are _5_ unresolved linting errors which are yet to be handled -
 because of this, we're currently not running linting as part of CI. Changes
 should not include any additional linting errors.
 
@@ -67,9 +67,6 @@ detector/database/cache.go:32:15: err113: do not define dynamic errors, use wrap
 detector/database/cache.go:36:30: should rewrite http.NewRequestWithContext or add (*Request).WithContext (noctx)
                 req, err := http.NewRequest("GET", db.ArchiveURL, nil)
                                            ^
-detector/parsers/parse-composer-lock.go:22:2: Consider preallocating `packages` (prealloc)
-        var packages []PackageDetails
-        ^
 detector/parsers/parse-npm-lock.go:32:2: Consider preallocating `details` (prealloc)
         var details []PackageDetails
         ^

--- a/detector/parsers/parse-composer-lock.go
+++ b/detector/parsers/parse-composer-lock.go
@@ -33,7 +33,11 @@ func ParseComposerLock(pathToLockfile string) ([]PackageDetails, error) {
 		return []PackageDetails{}, fmt.Errorf("could not parse %s: %w", pathToLockfile, err)
 	}
 
-	packages := make([]PackageDetails, 0, len(parsedLockfile.Packages)+len(parsedLockfile.PackagesDev))
+	packages := make(
+		[]PackageDetails,
+		0,
+		uint64(len(parsedLockfile.Packages)+len(parsedLockfile.PackagesDev)),
+	)
 
 	for _, composerPackage := range parsedLockfile.Packages {
 		packages = append(packages, PackageDetails{

--- a/detector/parsers/parse-composer-lock.go
+++ b/detector/parsers/parse-composer-lock.go
@@ -19,20 +19,21 @@ type ComposerLock struct {
 const ComposerEcosystem Ecosystem = "Packagist"
 
 func ParseComposerLock(pathToLockfile string) ([]PackageDetails, error) {
-	var packages []PackageDetails
 	var parsedLockfile *ComposerLock
 
 	lockfileContents, err := ioutil.ReadFile(pathToLockfile)
 
 	if err != nil {
-		return packages, fmt.Errorf("could not read %s: %w", pathToLockfile, err)
+		return []PackageDetails{}, fmt.Errorf("could not read %s: %w", pathToLockfile, err)
 	}
 
 	err = json.Unmarshal(lockfileContents, &parsedLockfile)
 
 	if err != nil {
-		return packages, fmt.Errorf("could not parse %s: %w", pathToLockfile, err)
+		return []PackageDetails{}, fmt.Errorf("could not parse %s: %w", pathToLockfile, err)
 	}
+
+	packages := make([]PackageDetails, 0, len(parsedLockfile.Packages)+len(parsedLockfile.PackagesDev))
 
 	for _, composerPackage := range parsedLockfile.Packages {
 		packages = append(packages, PackageDetails{

--- a/detector/parsers/parse-composer-lock.go
+++ b/detector/parsers/parse-composer-lock.go
@@ -36,7 +36,7 @@ func ParseComposerLock(pathToLockfile string) ([]PackageDetails, error) {
 	packages := make(
 		[]PackageDetails,
 		0,
-		uint64(len(parsedLockfile.Packages)+len(parsedLockfile.PackagesDev)),
+		uint64(len(parsedLockfile.Packages))+uint64(len(parsedLockfile.PackagesDev)),
 	)
 
 	for _, composerPackage := range parsedLockfile.Packages {


### PR DESCRIPTION
I realised while creating #26 we can take care of this one without worrying, since we're doing a merge.