### PR TITLE
pref: pre allocate some arrays

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ keep the codebase healthy, which can be run with:
 make lint
 ```
 
-Currently, there are _4_ unresolved linting errors which are yet to be handled -
+Currently, there is _1_ unresolved linting errors which are yet to be handled -
 because of this, we're currently not running linting as part of CI. Changes
 should not include any additional linting errors.
 
@@ -64,15 +64,6 @@ Here are the unresolved errors:
 detector/database/cache.go:36:30: should rewrite http.NewRequestWithContext or add (*Request).WithContext (noctx)
                 req, err := http.NewRequest("GET", db.ArchiveURL, nil)
                                            ^
-detector/parsers/parse-composer-lock.go:22:2: Consider preallocating `packages` (prealloc)
-        var packages []PackageDetails
-        ^
-detector/parsers/parse-npm-lock.go:32:2: Consider preallocating `details` (prealloc)
-        var details []PackageDetails
-        ^
-detector/parsers/parse-yarn-lock.go:99:2: Consider preallocating `packages` (prealloc)
-        var packages []PackageDetails
-        ^
 ```
 
 Markdown documents and yaml files should ideally be formatted with

--- a/detector/parsers/parse-composer-lock.go
+++ b/detector/parsers/parse-composer-lock.go
@@ -19,20 +19,26 @@ type ComposerLock struct {
 const ComposerEcosystem Ecosystem = "Packagist"
 
 func ParseComposerLock(pathToLockfile string) ([]PackageDetails, error) {
-	var packages []PackageDetails
 	var parsedLockfile *ComposerLock
 
 	lockfileContents, err := ioutil.ReadFile(pathToLockfile)
 
 	if err != nil {
-		return packages, fmt.Errorf("could not read %s: %w", pathToLockfile, err)
+		return []PackageDetails{}, fmt.Errorf("could not read %s: %w", pathToLockfile, err)
 	}
 
 	err = json.Unmarshal(lockfileContents, &parsedLockfile)
 
 	if err != nil {
-		return packages, fmt.Errorf("could not parse %s: %w", pathToLockfile, err)
+		return []PackageDetails{}, fmt.Errorf("could not parse %s: %w", pathToLockfile, err)
 	}
+
+	packages := make(
+		[]PackageDetails,
+		0,
+		// len cannot return negative numbers, but the types can't reflect that
+		uint64(len(parsedLockfile.Packages))+uint64(len(parsedLockfile.PackagesDev)),
+	)
 
 	for _, composerPackage := range parsedLockfile.Packages {
 		packages = append(packages, PackageDetails{

--- a/detector/parsers/parse-npm-lock.go
+++ b/detector/parsers/parse-npm-lock.go
@@ -29,7 +29,7 @@ type NpmLockfile struct {
 const NpmEcosystem Ecosystem = "npm"
 
 func pkgDetailsMapToSlice(m map[string]PackageDetails) []PackageDetails {
-	var details []PackageDetails
+	details := make([]PackageDetails, 0, len(m))
 
 	for _, detail := range m {
 		details = append(details, detail)

--- a/detector/parsers/parse-yarn-lock.go
+++ b/detector/parsers/parse-yarn-lock.go
@@ -96,11 +96,9 @@ func parsePackageGroup(group []string) PackageDetails {
 }
 
 func ParseYarnLock(pathToLockfile string) ([]PackageDetails, error) {
-	var packages []PackageDetails
-
 	file, err := os.Open(pathToLockfile)
 	if err != nil {
-		return packages, fmt.Errorf("could not open %s: %w", pathToLockfile, err)
+		return []PackageDetails{}, fmt.Errorf("could not open %s: %w", pathToLockfile, err)
 	}
 	defer file.Close()
 
@@ -109,8 +107,10 @@ func ParseYarnLock(pathToLockfile string) ([]PackageDetails, error) {
 	packageGroups := groupPackageLines(scanner)
 
 	if err := scanner.Err(); err != nil {
-		return packages, fmt.Errorf("error while scanning %s: %w", pathToLockfile, err)
+		return []PackageDetails{}, fmt.Errorf("error while scanning %s: %w", pathToLockfile, err)
 	}
+
+	packages := make([]PackageDetails, 0, len(packageGroups))
 
 	for _, group := range packageGroups {
 		if group[0] == "__metadata:" {


### PR DESCRIPTION
I realised that all the `prealloc` errors were actually valid, and that what I had in #27 is actually fine as `len` cannot return a negative it's just that Go currently cannot express that.

I _think_ that makes it completely safe (as the worse case should be that we overflow resulting in a smaller-than-required allocation which shouldn't result in the tool actually crashing)...