### PR TITLE
feat: include advisory link in output

### DIFF
--- a/detector/database/osv.go
+++ b/detector/database/osv.go
@@ -110,6 +110,10 @@ func (osv *OSV) AffectsEcosystem(ecosystem detector.Ecosystem) bool {
 	return false
 }
 
+func (osv *OSV) Link() string {
+	return "https://github.com/advisories/" + osv.ID
+}
+
 func (osv *OSV) IsAffected(pkg detector.PackageDetails) bool {
 	if osv.Affected == nil {
 		fmt.Printf("Ignoring %s as it does not have an 'affected' property\n", osv.ID)

--- a/main.go
+++ b/main.go
@@ -68,9 +68,10 @@ func printVulnerabilities(db database.OSVDatabase, pkg detector.PackageDetails) 
 
 	for _, vulnerability := range vulnerabilities {
 		fmt.Printf(
-			"  %s %s\n",
+			"  %s %s (%s)\n",
 			color.CyanString("%s:", vulnerability.ID),
 			vulnerability.Summary,
+			vulnerability.Link(),
 		)
 	}
 


### PR DESCRIPTION
I'm not the happiest about this as it adds a lot to the output in terms of wrapping given the potential size of the summaries, but there is still a lot of thinking to be done about the output formats, and I think having the advisory link is very important so for now it's worth it.