### PR TITLE
refactor: use `NewRequestWithContext` with background context

### DIFF
--- a/detector/database/cache.go
+++ b/detector/database/cache.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -35,7 +36,7 @@ func (db *OSVDatabase) fetchCache() (*Cache, error) {
 	}
 
 	if !db.Offline {
-		req, err := http.NewRequest("GET", db.ArchiveURL, nil)
+		req, err := http.NewRequestWithContext(context.Background(), "GET", db.ArchiveURL, nil)
 
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve OSV database archive: %w", err)


### PR DESCRIPTION
I'm pretty sure this doesn't actually help in the way the linter wants, but it was this or disabling it (inline) 🤷 

I get what it's wanting, but for now am not concerned since the rest of the tool isn't using it, and I'm currently not expecting people to be using this directly as a Go package (not that they couldn't if they want, just I'm focusing on the compiled tool for now)

Fixes #26