### PR TITLE
fix: support python packages that have "added support" syntax

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,6 +32,7 @@ issues:
     - path: _test\.go
       linters:
         - goerr113
+        - dupl
     - path: main.go
       linters:
         - gochecknoglobals

--- a/detector/parsers/fixtures/pip/with-added-support.txt
+++ b/detector/parsers/fixtures/pip/with-added-support.txt
@@ -1,0 +1,2 @@
+twisted[http2]==20.3.0
+    # via scrapy

--- a/detector/parsers/parse-requirements-txt.go
+++ b/detector/parsers/parse-requirements-txt.go
@@ -45,10 +45,14 @@ func parseLine(line string) PackageDetails {
 	}
 
 	return PackageDetails{
-		Name:      name,
+		Name:      cleanupRequirementName(name),
 		Version:   version,
 		Ecosystem: PipEcosystem,
 	}
+}
+
+func cleanupRequirementName(name string) string {
+	return strings.Split(name, "[")[0]
 }
 
 func removeComments(line string) string {

--- a/detector/parsers/parse-requirements-txt_test.go
+++ b/detector/parsers/parse-requirements-txt_test.go
@@ -262,3 +262,21 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 		},
 	})
 }
+
+func TestParseRequirementsTxt_WithAddedSupport(t *testing.T) {
+	t.Parallel()
+
+	packages, err := parsers.ParseRequirementsTxt("fixtures/pip/with-added-support.txt")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []parsers.PackageDetails{
+		{
+			Name:      "twisted",
+			Version:   "20.3.0",
+			Ecosystem: parsers.PipEcosystem,
+		},
+	})
+}


### PR DESCRIPTION
I'm pretty sure that technically the advisories are actually wrong as e.g. `twisted[http2]` is technically a different package to `twisted` itself but I can understand that it'd make the number of advisories to maintain grow by a large factor.

At this point I think it's less likely that an advisory will be missed with this change than without it, but if we find later one is being missed, we'll deal with it somehow 🤷 