### PR TITLE
fix: normalize names of python packages to favor false positives over false negatives

### DIFF
--- a/detector/parsers/fixtures/pip/non-normalized-names.txt
+++ b/detector/parsers/fixtures/pip/non-normalized-names.txt
@@ -1,0 +1,9 @@
+zope.interface==5.4.0
+    # via
+    #   scrapy
+    #   twisted
+
+Pillow==1.0.0
+
+Twisted[http2]==20.3.0
+    # via scrapy

--- a/detector/parsers/parse-requirements-txt.go
+++ b/detector/parsers/parse-requirements-txt.go
@@ -45,14 +45,30 @@ func parseLine(line string) PackageDetails {
 	}
 
 	return PackageDetails{
-		Name:      cleanupRequirementName(name),
+		Name:      normalizedRequirementName(name),
 		Version:   version,
 		Ecosystem: PipEcosystem,
 	}
 }
 
-func cleanupRequirementName(name string) string {
-	return strings.Split(name, "[")[0]
+// normalizedName ensures that the package name is normalized per PEP-0503
+// and then removing "added support" syntax if present.
+//
+// This is done to ensure we don't miss any advisories, as while the OSV
+// specification says that the normalized name should be used for advisories,
+// that's not the case currently in our databases, _and_ Pip itself supports
+// non-normalized names in the requirements.txt, so we need to normalize
+// on both sides to ensure we don't have false negatives.
+//
+// It's possible that this will cause some false positives, but that is better
+// than false negatives, and can be dealt with when/if it actually happens.
+func normalizedRequirementName(name string) string {
+	// per https://www.python.org/dev/peps/pep-0503/#normalized-names
+	name = regexp.MustCompile(`[-_.]+`).ReplaceAllString(name, "-")
+	name = strings.ToLower(name)
+	name = strings.Split(name, "[")[0]
+
+	return name
 }
 
 func removeComments(line string) string {

--- a/detector/parsers/parse-requirements-txt_test.go
+++ b/detector/parsers/parse-requirements-txt_test.go
@@ -246,7 +246,7 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 			Ecosystem: parsers.PipEcosystem,
 		},
 		{
-			Name:      "Mopidy-Dirble",
+			Name:      "mopidy-dirble",
 			Version:   "1.1",
 			Ecosystem: parsers.PipEcosystem,
 		},
@@ -273,6 +273,34 @@ func TestParseRequirementsTxt_WithAddedSupport(t *testing.T) {
 	}
 
 	expectPackages(t, packages, []parsers.PackageDetails{
+		{
+			Name:      "twisted",
+			Version:   "20.3.0",
+			Ecosystem: parsers.PipEcosystem,
+		},
+	})
+}
+
+func TestParseRequirementsTxt_NonNormalizedNames(t *testing.T) {
+	t.Parallel()
+
+	packages, err := parsers.ParseRequirementsTxt("fixtures/pip/non-normalized-names.txt")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []parsers.PackageDetails{
+		{
+			Name:      "zope-interface",
+			Version:   "5.4.0",
+			Ecosystem: parsers.PipEcosystem,
+		},
+		{
+			Name:      "pillow",
+			Version:   "1.0.0",
+			Ecosystem: parsers.PipEcosystem,
+		},
 		{
 			Name:      "twisted",
 			Version:   "20.3.0",


### PR DESCRIPTION
The comments should say it all - ultimately I realised that `pip-compile` is probably why all the `requirements.txt` I have locally are using lowercase package names, and that pip probably just accepts either or and normailizes names internally.

Ultimately the OSV spec says that the name for packages in the PyPip ecosystem should be normalized, so let's normalize the names on both sides and call it a day for the time being.