### PR TITLE
feat: use osv.dev databases instead of github advisory database

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,21 @@ flag:
 osv-detector --parse-as 'package-lock.json' path/to/my/file.lock
 ```
 
-The detector maintains a cache of the OSV database it's using locally, which is
-updated with any changes at the start of every run.
+Once packages have been parsed, the detector determines which ecosystem
+databases it needs to load from its cache. If an ecosystem database does not
+exist locally, or if the database is outdated, the detector downloads a new
+version and stores it for re-use.
 
-You can have the detector work solely off this cache with the `--offline` flag:
+You can have the detector work solely off the local version of the databases
+with the `--offline` flag:
 
 ```shell
-osv-detector --offline
+osv-detector --offline path/to/my/file.lock
 ```
 
-This requires the detector to have successfully cached an offline copy of the
-OSV database at least once.
+This requires the detector to have successfully downloaded a copy of ecosystem
+databases required to check the packages discovered during parsing at least
+once.
 
 ### Auxiliary output commands
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Open Source Vulnerability Detector
 
-An auditing tool for detecting vulnerabilities using the
-[Open Source Vulnerability advisory database provided by GitHub](https://github.com/github/advisory-database)
+An auditing tool for detecting vulnerabilities, powered by advisory databases
+that follow the [OSV specification](https://ossf.github.io/osv-schema/).
+
+Currently, this uses the ecosystem databases provided by
+[osv.dev](https://osv.dev/).
 
 ## Usage
 

--- a/detector/database/cache.go
+++ b/detector/database/cache.go
@@ -14,6 +14,7 @@ import (
 
 // Cache stores the GitHub response to save bandwidth
 type Cache struct {
+	URL  string
 	ETag string
 	Date string
 	Body []byte
@@ -78,7 +79,7 @@ func (db *OSVDatabase) fetchCache() (*Cache, error) {
 		date := resp.Header.Get("Date")
 
 		if etag != "" || date != "" {
-			cache = &Cache{ETag: etag, Date: date, Body: body}
+			cache = &Cache{ETag: etag, Date: date, Body: body, URL: db.ArchiveURL}
 		}
 
 		cacheContents, err := json.Marshal(cache)

--- a/detector/database/cache.go
+++ b/detector/database/cache.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 )
 
-// Cache stores the GitHub response to save bandwidth
+// Cache stores the OSV database archive for re-use
 type Cache struct {
 	URL  string
 	ETag string

--- a/detector/database/cache.go
+++ b/detector/database/cache.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -20,9 +21,16 @@ type Cache struct {
 
 var ErrOfflineDatabaseNotFound = errors.New("no offline version of the OSV database is available")
 
+func (db *OSVDatabase) cachePath() string {
+	hash := sha256.Sum256([]byte(db.ArchiveURL))
+	fileName := fmt.Sprintf("osv-detector-%x-db.json", hash)
+
+	return filepath.Join(os.TempDir(), fileName)
+}
+
 func (db *OSVDatabase) fetchCache() (*Cache, error) {
 	var cache *Cache
-	cachePath := filepath.Join(os.TempDir(), "osv-detector-db.json")
+	cachePath := db.cachePath()
 	if cacheContent, err := ioutil.ReadFile(cachePath); err == nil {
 		err := json.Unmarshal(cacheContent, &cache)
 

--- a/detector/database/load.go
+++ b/detector/database/load.go
@@ -10,9 +10,6 @@ import (
 	"strings"
 )
 
-// GithubOSVDatabaseArchiveURL represents GitHub's OSV database URL
-const GithubOSVDatabaseArchiveURL = "https://codeload.github.com/github/advisory-database/zip/main"
-
 // load fetches a zip archive of the OSV database and loads known vulnerabilities
 // from it (which are assumed to be in json files following the OSV spec).
 //
@@ -37,11 +34,6 @@ func (db *OSVDatabase) load() error {
 
 	// Read all the files from the zip archive
 	for _, zipFile := range zipReader.File {
-		// todo: somehow support passing these excludes generically, so it's more agnostic
-		if !strings.HasPrefix(zipFile.Name, "advisory-database-main/advisories") {
-			continue
-		}
-
 		if strings.HasPrefix(zipFile.Name, "advisory-database-main/advisories/unreviewed") {
 			continue
 		}

--- a/detector/database/new.go
+++ b/detector/database/new.go
@@ -10,11 +10,7 @@ type OSVDatabase struct {
 	UpdatedAt       string
 }
 
-// todo: support settings, including "way to load database"
-// e.g. we want to set rules for how to exclude json files
-// that way it'll be more agnostic
-
-// NewDB fetches the advisory DB from GitHub
+// NewDB creates an OSV database with vulnerabilities loaded from an archive
 func NewDB(offline bool, dbArchiveURL string) (*OSVDatabase, error) {
 	db := &OSVDatabase{Offline: offline, ArchiveURL: dbArchiveURL}
 	if err := db.load(); err != nil {

--- a/detector/parsers/parsers.go
+++ b/detector/parsers/parsers.go
@@ -32,7 +32,35 @@ func findParser(pathToLockfile string) PackageDetailsParser {
 
 var ErrParserNotFound = errors.New("could not determine parser")
 
-func TryParse(pathToLockfile string, parseAs string) ([]PackageDetails, error) {
+type Packages []PackageDetails
+
+func toSliceOfEcosystems(ecosystemsMap map[Ecosystem]struct{}) []Ecosystem {
+	ecosystems := make([]Ecosystem, 0, len(ecosystemsMap))
+
+	for ecosystem := range ecosystemsMap {
+		ecosystems = append(ecosystems, ecosystem)
+	}
+
+	return ecosystems
+}
+
+func (ps Packages) Ecosystems() []Ecosystem {
+	ecosystems := make(map[Ecosystem]struct{})
+
+	for _, pkg := range ps {
+		ecosystems[pkg.Ecosystem] = struct{}{}
+	}
+
+	slicedEcosystems := toSliceOfEcosystems(ecosystems)
+
+	sort.Slice(slicedEcosystems, func(i, j int) bool {
+		return slicedEcosystems[i] < slicedEcosystems[j]
+	})
+
+	return slicedEcosystems
+}
+
+func TryParse(pathToLockfile string, parseAs string) (Packages, error) {
 	if parseAs == "" {
 		parseAs = path.Base(pathToLockfile)
 	}

--- a/main.go
+++ b/main.go
@@ -23,13 +23,13 @@ func loadOSVDatabase(offline bool, archiveURL string) database.OSVDatabase {
 	db, err := database.NewDB(offline, archiveURL)
 
 	if err != nil {
-		msg := fmt.Sprintf("Error loading the OSV DB: %s", err)
+		msg := err.Error()
 
 		if errors.Is(err, database.ErrOfflineDatabaseNotFound) {
-			msg = "Error: --offline can only be used when a local version of the OSV database is available"
+			msg = color.RedString("no local version of the database was found, and --offline flag was set")
 		}
 
-		_, _ = fmt.Fprintf(os.Stderr, "%s\n", msg)
+		_, _ = fmt.Fprintf(os.Stderr, " %s\n", color.RedString("failed: %s", msg))
 		os.Exit(127)
 	}
 
@@ -88,7 +88,7 @@ type OSVDatabases []database.OSVDatabase
 func loadEcosystemDatabases(ecosystems []detector.Ecosystem, offline bool) OSVDatabases {
 	dbs := make(OSVDatabases, 0, len(ecosystems))
 
-	fmt.Printf("Loaded OSV databases for the following ecosystems:\n")
+	fmt.Printf("Loading OSV databases for the following ecosystems:\n")
 
 	for _, ecosystem := range ecosystems {
 		fmt.Printf("  %s", ecosystem)

--- a/main.go
+++ b/main.go
@@ -19,8 +19,8 @@ var (
 	date    = "unknown"
 )
 
-func loadOSVDatabase(offline bool) database.OSVDatabase {
-	db, err := database.NewDB(offline, database.GithubOSVDatabaseArchiveURL)
+func loadOSVDatabase(offline bool, archiveURL string) database.OSVDatabase {
+	db, err := database.NewDB(offline, archiveURL)
 
 	if err != nil {
 		msg := fmt.Sprintf("Error loading the OSV DB: %s", err)
@@ -32,12 +32,6 @@ func loadOSVDatabase(offline bool) database.OSVDatabase {
 		_, _ = fmt.Fprintf(os.Stderr, "%s\n", msg)
 		os.Exit(127)
 	}
-
-	fmt.Printf(
-		"Loaded %s vulnerabilities (including withdrawn, last updated %s)\n",
-		color.YellowString("%d", len(db.Vulnerabilities(true))),
-		db.UpdatedAt,
-	)
 
 	return *db
 }
@@ -85,6 +79,37 @@ func printVulnerabilities(db database.OSVDatabase, pkg detector.PackageDetails) 
 	return len(vulnerabilities)
 }
 
+func ecosystemDatabaseURL(ecosystem detector.Ecosystem) string {
+	return fmt.Sprintf("https://osv-vulnerabilities.storage.googleapis.com/%s/all.zip", ecosystem)
+}
+
+type OSVDatabases []database.OSVDatabase
+
+func loadEcosystemDatabases(ecosystems []detector.Ecosystem, offline bool) OSVDatabases {
+	dbs := make(OSVDatabases, 0, len(ecosystems))
+
+	fmt.Printf("Loaded OSV databases for the following ecosystems:\n")
+
+	for _, ecosystem := range ecosystems {
+		fmt.Printf("  %s", ecosystem)
+		archiveURL := ecosystemDatabaseURL(ecosystem)
+
+		db := loadOSVDatabase(offline, archiveURL)
+
+		fmt.Printf(
+			" (%s vulnerabilities, including withdrawn - last updated %s)\n",
+			color.YellowString("%d", len(db.Vulnerabilities(true))),
+			db.UpdatedAt,
+		)
+
+		dbs = append(dbs, db)
+	}
+
+	fmt.Println()
+
+	return dbs
+}
+
 func main() {
 	offline := flag.Bool("offline", false, "Update the OSV database")
 	parseAs := flag.String("parse-as", "", "Name of a supported lockfile to use to determine how to parse the given file")
@@ -101,13 +126,6 @@ func main() {
 
 	pathToLockOrDirectory := flag.Arg(0)
 
-	db := loadOSVDatabase(*offline)
-
-	if *listEcosystems {
-		printEcosystems(db)
-		os.Exit(0)
-	}
-
 	packages, err := parsers.TryParse(pathToLockOrDirectory, *parseAs)
 
 	if err != nil {
@@ -120,11 +138,22 @@ func main() {
 		os.Exit(0)
 	}
 
+	dbs := loadEcosystemDatabases(packages.Ecosystems(), *offline)
+
+	if *listEcosystems {
+		for _, db := range dbs {
+			printEcosystems(db)
+		}
+		os.Exit(0)
+	}
+
 	file := path.Base(pathToLockOrDirectory)
 
 	knownVulnerabilitiesCount := 0
 	for _, pkg := range packages {
-		knownVulnerabilitiesCount += printVulnerabilities(db, pkg)
+		for _, db := range dbs {
+			knownVulnerabilitiesCount += printVulnerabilities(db, pkg)
+		}
 	}
 
 	if knownVulnerabilitiesCount == 0 {


### PR DESCRIPTION
This is working, but there's a few tweaks still to be made, and will also have some follow ups.

Resolves #53 