### PR TITLE
fix: improve description of OSVs to handle summary not being present + linking to non GH advisories

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,10 +69,9 @@ func printVulnerabilities(db database.OSVDatabase, pkg detector.PackageDetails) 
 
 	for _, vulnerability := range vulnerabilities {
 		fmt.Printf(
-			"  %s %s (%s)\n",
+			"  %s %s\n",
 			color.CyanString("%s:", vulnerability.ID),
-			vulnerability.Summary,
-			vulnerability.Link(),
+			vulnerability.Describe(),
 		)
 	}
 


### PR DESCRIPTION
The output format is slowly getting better 😄 

Currently I'm applying truncation to just the "details" text as the summaries seem short enough and really this is meant to be a fallback now that we're using more than just the GH advisory database.

I have just realised a slight improvement for linking would be to check if the `aliases` contain any GHSA IDs - will do that in a follow-up PR.