### PR TITLE
fix: don't report vulnerabilities multiple times under different aliases

### DIFF
--- a/detector/database/osv.go
+++ b/detector/database/osv.go
@@ -122,12 +122,33 @@ type Affected struct {
 // OSV represents an OSV style JSON vulnerability database entry
 type OSV struct {
 	ID        string     `json:"id"`
+	Aliases   []string   `json:"aliases"`
 	Summary   string     `json:"summary"`
 	Published time.Time  `json:"published"`
 	Modified  time.Time  `json:"modified"`
 	Withdrawn *time.Time `json:"withdrawn,omitempty"`
 	Details   string     `json:"details"`
 	Affected  []Affected `json:"affected"`
+}
+
+func (osv *OSV) isAliasOfID(id string) bool {
+	for _, alias := range osv.Aliases {
+		if alias == id {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (osv *OSV) isAliasOf(vulnerability OSV) bool {
+	for _, alias := range vulnerability.Aliases {
+		if osv.ID == alias || osv.isAliasOfID(alias) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (osv *OSV) AffectsEcosystem(ecosystem detector.Ecosystem) bool {

--- a/detector/database/vulnerabilities.go
+++ b/detector/database/vulnerabilities.go
@@ -20,11 +20,30 @@ func (db *OSVDatabase) Vulnerabilities(includeWithdrawn bool) []OSV {
 	return vulnerabilities
 }
 
-func (db *OSVDatabase) VulnerabilitiesAffectingPackage(pkg detector.PackageDetails) []OSV {
-	var vulnerabilities []OSV
+type Vulnerabilities []OSV
+
+func (vs Vulnerabilities) Includes(vulnerability OSV) bool {
+	for _, osv := range vs {
+		if osv.ID == vulnerability.ID {
+			return true
+		}
+
+		if osv.isAliasOf(vulnerability) {
+			return true
+		}
+		if vulnerability.isAliasOf(osv) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (db *OSVDatabase) VulnerabilitiesAffectingPackage(pkg detector.PackageDetails) Vulnerabilities {
+	var vulnerabilities Vulnerabilities
 
 	for _, vulnerability := range db.Vulnerabilities(false) {
-		if vulnerability.IsAffected(pkg) {
+		if vulnerability.IsAffected(pkg) && !vulnerabilities.Includes(vulnerability) {
 			vulnerabilities = append(vulnerabilities, vulnerability)
 		}
 	}

--- a/detector/database/vulnerabilities_test.go
+++ b/detector/database/vulnerabilities_test.go
@@ -1,0 +1,127 @@
+package database_test
+
+import (
+	"osv-detector/detector/database"
+	"testing"
+)
+
+func TestVulnerabilities_Includes(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		osv database.OSV
+	}
+	tests := []struct {
+		name string
+		vs   database.Vulnerabilities
+		args args
+		want bool
+	}{
+		{
+			name: "",
+			vs: database.Vulnerabilities{
+				database.OSV{
+					ID:      "GHSA-1",
+					Aliases: []string{},
+				},
+			},
+			args: args{
+				osv: database.OSV{
+					ID:      "GHSA-2",
+					Aliases: []string{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "",
+			vs: database.Vulnerabilities{
+				database.OSV{
+					ID:      "GHSA-1",
+					Aliases: []string{},
+				},
+			},
+			args: args{
+				osv: database.OSV{
+					ID:      "GHSA-1",
+					Aliases: []string{},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "",
+			vs: database.Vulnerabilities{
+				database.OSV{
+					ID:      "GHSA-1",
+					Aliases: []string{"GHSA-2"},
+				},
+			},
+			args: args{
+				osv: database.OSV{
+					ID:      "GHSA-2",
+					Aliases: []string{},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "",
+			vs: database.Vulnerabilities{
+				database.OSV{
+					ID:      "GHSA-1",
+					Aliases: []string{},
+				},
+			},
+			args: args{
+				osv: database.OSV{
+					ID:      "GHSA-2",
+					Aliases: []string{"GHSA-1"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "",
+			vs: database.Vulnerabilities{
+				database.OSV{
+					ID:      "GHSA-1",
+					Aliases: []string{"CVE-1"},
+				},
+			},
+			args: args{
+				osv: database.OSV{
+					ID:      "GHSA-2",
+					Aliases: []string{"CVE-1"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "",
+			vs: database.Vulnerabilities{
+				database.OSV{
+					ID:      "GHSA-1",
+					Aliases: []string{"CVE-2"},
+				},
+			},
+			args: args{
+				osv: database.OSV{
+					ID:      "GHSA-2",
+					Aliases: []string{"CVE-2"},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.vs.Includes(tt.args.osv); got != tt.want {
+				t.Errorf("Includes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Not super happy about this one as it feels really inefficient to be constantly doing the same bunch of loops over and over, but I can't think of a more efficient way of doing this - the main issue is that not everyone lists all their aliases, so we just have to check them from every angle...

This messed with my brain a bunch, so I've made `Include` public for now to be able to have a explicit test but will replace that once I've had time to look into writing tests for the database (which require running a test http server to provide the db archive).

Overall this is primarily "just" for the PyPip ecosystem as their database has both GHSA and PYSEC vulnerabilities, with the GHSA ones having been pulled from PYSEC in the first place; however what they are doing is completely valid so we should be having this logic as any database could do it.

Oh and currently this is first-in-wins based which means GHSAs "win" over PYSEC since they're listed alphabetically, but I expect GHSA entries to always be more fulsome so it would be nice at some point to look into having them be preferred as part of this logic (though that'd also be adding more expense, since we'd have to recompute the splice to replace the entry, maybe?)

(btw while I'm talking about this as being inefficient, it's relative - I expect this is a lot faster than it actually looks, because Go 🤷)