### PR TITLE
refactor: rename `lockfile.TryParse` to `lockfile.Parse`

### DIFF
--- a/internal/lockfile/parse.go
+++ b/internal/lockfile/parse.go
@@ -60,7 +60,12 @@ func (ps Packages) Ecosystems() []Ecosystem {
 	return slicedEcosystems
 }
 
-func TryParse(pathToLockfile string, parseAs string) (Packages, error) {
+// Parse attempts to extract a collection of package details from a lockfile,
+// using one of the native parsers.
+//
+// The parser is selected based on the name of the file, which can be overridden
+// with the "parseAs" parameter.
+func Parse(pathToLockfile string, parseAs string) (Packages, error) {
 	if parseAs == "" {
 		parseAs = path.Base(pathToLockfile)
 	}

--- a/internal/lockfile/parse_test.go
+++ b/internal/lockfile/parse_test.go
@@ -52,7 +52,7 @@ func TestTryParse_FindsExpectedParsers(t *testing.T) {
 	count := 0
 
 	for _, file := range lockfiles {
-		_, err := lockfile.TryParse("/path/to/my/"+file, "")
+		_, err := lockfile.Parse("/path/to/my/"+file, "")
 
 		if errors.Is(err, lockfile.ErrParserNotFound) {
 			t.Errorf("No parser was found for %s", file)

--- a/main.go
+++ b/main.go
@@ -125,7 +125,7 @@ func main() {
 
 	pathToLockOrDirectory := flag.Arg(0)
 
-	packages, err := lockfile.TryParse(pathToLockOrDirectory, *parseAs)
+	packages, err := lockfile.Parse(pathToLockOrDirectory, *parseAs)
 
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error, %s\n", err)


### PR DESCRIPTION
It's a little more accurate, as the "try" part is represented by it returning `error`.