### PR TITLE
fix: make `list-ecosystems` flag actually useful again

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,23 +74,18 @@ which can be useful for debugging issues and general exploring.
 
 #### `--list-ecosystems`
 
-Lists all the ecosystems that exist in the loaded OSV database. This can be
-useful when exploring new parsers, or building wrappers around the detector
-since a valid ecosystem is required to determine if a package has a
-vulnerability, and the ecosystem names are case-sensitive:
+Lists all the ecosystems that the detector knows about (aka there is a parser
+that results in packages from that ecosystem):
 
 ```
 $ osv-detector --list-ecosystems
-Loaded 6532 vulnerabilities (including withdrawn, last updated Fri, 04 Mar 2022 00:11:50 GMT)
-The loaded OSV has vulnerabilities for the following ecosystems:
-  Packagist
-  Go
+The detector supports parsing for the following ecosystems:
+  npm
   crates.io
   RubyGems
-  npm
+  Packagist
+  Go
   PyPI
-  Maven
-  NuGet
 ```
 
 #### `--list-packages`

--- a/main.go
+++ b/main.go
@@ -36,10 +36,10 @@ func loadOSVDatabase(offline bool, archiveURL string) database.OSVDatabase {
 	return *db
 }
 
-func printEcosystems(db database.OSVDatabase) {
-	ecosystems := db.ListEcosystems()
+func printKnownEcosystems() {
+	ecosystems := lockfile.KnownEcosystems()
 
-	fmt.Println("The loaded OSV has vulnerabilities for the following ecosystems:")
+	fmt.Println("The detector supports parsing for the following ecosystems:")
 
 	for _, ecosystem := range ecosystems {
 		fmt.Printf("  %s\n", ecosystem)
@@ -135,6 +135,11 @@ func main() {
 		os.Exit(0)
 	}
 
+	if *listEcosystems {
+		printKnownEcosystems()
+		os.Exit(0)
+	}
+
 	pathToLockOrDirectory := flag.Arg(0)
 
 	packages, err := lockfile.Parse(pathToLockOrDirectory, *parseAs)
@@ -150,13 +155,6 @@ func main() {
 	}
 
 	dbs := loadEcosystemDatabases(packages.Ecosystems(), *offline)
-
-	if *listEcosystems {
-		for _, db := range dbs {
-			printEcosystems(db)
-		}
-		os.Exit(0)
-	}
 
 	file := path.Base(pathToLockOrDirectory)
 


### PR DESCRIPTION
It's not that useful since we list the ecosystems in the readme, but it was this or remove it and it might become more useful later 🤷 