### PR TITLE
fix: sort packages with the same name by their versions

### DIFF
--- a/internal/lockfile/parse.go
+++ b/internal/lockfile/parse.go
@@ -79,6 +79,10 @@ func Parse(pathToLockfile string, parseAs string) (Packages, error) {
 	packages, err := parser(pathToLockfile)
 
 	sort.Slice(packages, func(i, j int) bool {
+		if packages[i].Name == packages[j].Name {
+			return packages[i].Version < packages[j].Version
+		}
+
 		return packages[i].Name < packages[j].Name
 	})
 


### PR DESCRIPTION
This ensures that the output is consistent over multiple audit runs, which makes it easier to compare. 