### PR TITLE
feat: support being passed multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ versions of packages:
 ```shell
 osv-detector path/to/my/package-lock.json
 osv-detector path/to/my/composer.lock
+
+# you can also pass multiple files
+osv-detector path/to/my/package-lock.json path/to/my/composer.lock
 ```
 
 The detector supports parsing the following lockfiles:
@@ -33,9 +36,9 @@ The detector supports parsing the following lockfiles:
 that is not a direct requirement (e.g. flags or files) & it assumes the _lowest_
 version possible for the constraint (or lack of)
 
-The detector will attempt to automatically determine the parser to use based on
-the filename - you can manually specify the parser to use with the `-parse-as`
-flag:
+The detector will attempt to automatically determine the parser to use for each
+file based on the filename - you can manually specify the parser to use for all
+files with the `-parse-as` flag:
 
 ```shell
 osv-detector --parse-as 'package-lock.json' path/to/my/file.lock


### PR DESCRIPTION
This also tweaks the output a bit - I'm not strictly super super happy with it, but it should be fine 🤷 (I think the colors might be overkill, and the indenting, but will play around with some stuff later)

Technically we could optimise the database loading to avoid re-loading databases for ecosystems we're already loaded in previous loops, but currently it doesn't impact speed to be worth the complexity.

I also realised if we had a flag like `--ignore-unknown-files`, this would allow you to do `osv-detector */**` and co 🤔 

Resolves #12