### PR TITLE
fix: remove unneeded debug logs

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,7 +5,6 @@ linters:
   disable:
     - tagliatelle      # we're parsing data from external sources
     - varnamelen       # maybe later
-    - forbidigo        # defaults to fmt.Print stuff, which we want
     - exhaustivestruct # overkill
     - forcetypeassert  # too hard
     - interfacer       # deprecated

--- a/internal/database/ecosystems.go
+++ b/internal/database/ecosystems.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"fmt"
 	"sort"
 )
 
@@ -19,12 +18,6 @@ func (db *OSVDatabase) ListEcosystems() []Ecosystem {
 	ecosystems := make(map[Ecosystem]struct{})
 
 	for _, vulnerability := range db.Vulnerabilities(true) {
-		if vulnerability.Affected == nil {
-			fmt.Printf("Skipping %s as it does not have an 'affected' property", vulnerability.ID)
-
-			continue
-		}
-
 		for _, affected := range vulnerability.Affected {
 			ecosystems[affected.Package.Ecosystem] = struct{}{}
 		}
@@ -43,12 +36,6 @@ func (db *OSVDatabase) ListEcosystemVulnerabilities(ecosystem Ecosystem) []OSV {
 	var vulnerabilities []OSV
 
 	for _, vulnerability := range db.Vulnerabilities(false) {
-		if vulnerability.Affected == nil {
-			fmt.Printf("Skipping %s as it does not have an 'affected' property", vulnerability.ID)
-
-			continue
-		}
-
 		if vulnerability.AffectsEcosystem(ecosystem) {
 			vulnerabilities = append(vulnerabilities, vulnerability)
 		}

--- a/internal/database/osv.go
+++ b/internal/database/osv.go
@@ -169,12 +169,6 @@ func (osv *OSV) isAliasOf(vulnerability OSV) bool {
 }
 
 func (osv *OSV) AffectsEcosystem(ecosystem internal.Ecosystem) bool {
-	if osv.Affected == nil {
-		fmt.Printf("Ignoring %s as it does not have an 'affected' property\n", osv.ID)
-
-		return false
-	}
-
 	for _, affected := range osv.Affected {
 		if affected.Package.Ecosystem == ecosystem {
 			return true
@@ -243,12 +237,6 @@ func (osv *OSV) Link() string {
 }
 
 func (osv *OSV) IsAffected(pkg internal.PackageDetails) bool {
-	if osv.Affected == nil {
-		fmt.Printf("Ignoring %s as it does not have an 'affected' property\n", osv.ID)
-
-		return false
-	}
-
 	for _, affected := range osv.Affected {
 		if affected.Package.Ecosystem == pkg.Ecosystem &&
 			affected.Package.NormalizedName() == pkg.Name {


### PR DESCRIPTION
Now that we're got a reporter, ideally all output should be done through that to ensure we're always outputting valid JSON to `stdout` when that mode is enabled.

Ironically, we can enable the `forbidigo` linter to help enforce this.