### PR TITLE
fix: prepend directory path when finding lockfiles in a directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"osv-detector/internal/database"
 	"osv-detector/internal/lockfile"
 	"osv-detector/internal/reporter"
+	"path"
 )
 
 // these come from goreleaser
@@ -127,7 +128,7 @@ func findLockfiles(r *reporter.Reporter, pathToLockOrDirectory string, parseAs s
 							continue
 						}
 
-						lockfiles = append(lockfiles, dir.Name())
+						lockfiles = append(lockfiles, path.Join(pathToLockOrDirectory, dir.Name()))
 					}
 				}
 			} else {


### PR DESCRIPTION
Not really surprised a bug like this slipped through 🤷 