### PR TITLE
feat: support parsing pom.xml / maven / java

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,15 @@ The detector supports parsing the following lockfiles:
 | `composer.lock`      | `Packagist` | `composer` |
 | `Gemfile.lock`       | `RubyGems`  | `bundler`  |
 | `go.mod`             | `Go`        | `go mod`   |
+| `pom.xml`\*          | `Maven`     | `maven`    |
 | `requirements.txt`\* | `PyPI`      | `pip`      |
 
-\*: `requirements.txt` support is currently very limited - it ignores anything
-that is not a direct requirement (e.g. flags or files) & it assumes the _lowest_
-version possible for the constraint (or lack of)
+\*: `pom.xml` and `requirements.txt` are technically not lockfiles, as they
+don't have to specify the complete dependency tree and can have version
+constraints/ranges. When parsing these files, the detector will assume the
+_lowest_ version possible for non-exact dependencies, and will ignore anything
+that is not a dependency specification (e.g. flags or files in the case of
+`requirements.txt`, though `<properties>` _is_ supported for `pom.xml`)
 
 The detector will attempt to automatically determine the parser to use for each
 file based on the filename - you can manually specify the parser to use for all

--- a/internal/lockfile/ecosystems.go
+++ b/internal/lockfile/ecosystems.go
@@ -7,6 +7,7 @@ func KnownEcosystems() []Ecosystem {
 		BundlerEcosystem,
 		ComposerEcosystem,
 		GoEcosystem,
+		MavenEcosystem,
 		PipEcosystem,
 	}
 }

--- a/internal/lockfile/fixtures/maven/empty.xml
+++ b/internal/lockfile/fixtures/maven/empty.xml
@@ -1,0 +1,7 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1</version>
+</project>

--- a/internal/lockfile/fixtures/maven/interpolation.xml
+++ b/internal/lockfile/fixtures/maven/interpolation.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.library</groupId>
+  <artifactId>my-library</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <mypackageVersion>1.0.0</mypackageVersion>
+    <my.package.version>2.3.4</my.package.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.mine</groupId>
+      <artifactId>mypackage</artifactId>
+      <version>${mypackageVersion}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mine</groupId>
+      <artifactId>my.package</artifactId>
+      <version>${my.package.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/internal/lockfile/fixtures/maven/interpolation.xml
+++ b/internal/lockfile/fixtures/maven/interpolation.xml
@@ -11,6 +11,7 @@
   <properties>
     <mypackageVersion>1.0.0</mypackageVersion>
     <my.package.version>2.3.4</my.package.version>
+    <version-range>[9.4.35.v20201120,9.5)</version-range>
   </properties>
 
   <dependencies>
@@ -24,6 +25,12 @@
       <groupId>org.mine</groupId>
       <artifactId>my.package</artifactId>
       <version>${my.package.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mine</groupId>
+      <artifactId>ranged-package</artifactId>
+      <version>${version-range}</version>
     </dependency>
   </dependencies>
 </project>

--- a/internal/lockfile/fixtures/maven/not-pom.txt
+++ b/internal/lockfile/fixtures/maven/not-pom.txt
@@ -1,0 +1,1 @@
+this is not a pom.xml file!

--- a/internal/lockfile/fixtures/maven/one-package.xml
+++ b/internal/lockfile/fixtures/maven/one-package.xml
@@ -1,0 +1,13 @@
+<project>
+  <properties>
+    <mavenVersion>3.0</mavenVersion>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/internal/lockfile/fixtures/maven/two-packages.xml
+++ b/internal/lockfile/fixtures/maven/two-packages.xml
@@ -1,0 +1,18 @@
+<project>
+  <properties>
+    <mavenVersion>3.0</mavenVersion>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <version>4.1.42.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.25</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/internal/lockfile/parse-maven-lock.go
+++ b/internal/lockfile/parse-maven-lock.go
@@ -9,10 +9,10 @@ import (
 )
 
 type MavenLockDependency struct {
-	// GroupId    string `xml:"groupId"`
-	XMLName xml.Name `xml:"dependency"`
-	Name    string   `xml:"artifactId"`
-	Version string   `xml:"version"`
+	XMLName    xml.Name `xml:"dependency"`
+	GroupID    string   `xml:"groupId"`
+	ArtifactID string   `xml:"artifactId"`
+	Version    string   `xml:"version"`
 }
 
 func (mld MavenLockDependency) parseResolvedVersion(version string) string {
@@ -43,7 +43,7 @@ func (mld MavenLockDependency) resolveVersionValue(lockfile MavenLockFile) strin
 	fmt.Fprintf(
 		os.Stderr,
 		"Failed to resolve version of %s: property \"%s\" could not be found",
-		mld.Name,
+		mld.GroupID+":"+mld.ArtifactID,
 		results[1],
 	)
 
@@ -112,7 +112,7 @@ func ParseMavenLock(pathToLockfile string) ([]PackageDetails, error) {
 
 	for _, lockPackage := range parsedLockfile.Dependencies {
 		packages = append(packages, PackageDetails{
-			Name:      lockPackage.Name,
+			Name:      lockPackage.GroupID + ":" + lockPackage.ArtifactID,
 			Version:   lockPackage.ResolveVersion(*parsedLockfile),
 			Ecosystem: MavenEcosystem,
 		})

--- a/internal/lockfile/parse-maven-lock.go
+++ b/internal/lockfile/parse-maven-lock.go
@@ -1,0 +1,50 @@
+package lockfile
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+)
+
+type MavenLockDependency struct {
+	// GroupId    string `xml:"groupId"`
+	XMLName xml.Name `xml:"dependency"`
+	Name    string   `xml:"artifactId"`
+	Version string   `xml:"version"`
+}
+
+type MavenLockFile struct {
+	XMLName      xml.Name              `xml:"project"`
+	ModelVersion string                `xml:"modelVersion"`
+	Dependencies []MavenLockDependency `xml:"dependencies>dependency"`
+}
+
+const MavenEcosystem Ecosystem = "Maven"
+
+func ParseMavenLock(pathToLockfile string) ([]PackageDetails, error) {
+	var parsedLockfile *MavenLockFile
+
+	lockfileContents, err := ioutil.ReadFile(pathToLockfile)
+
+	if err != nil {
+		return []PackageDetails{}, fmt.Errorf("could not read %s: %w", pathToLockfile, err)
+	}
+
+	err = xml.Unmarshal(lockfileContents, &parsedLockfile)
+
+	if err != nil {
+		return []PackageDetails{}, fmt.Errorf("could not parse %s: %w", pathToLockfile, err)
+	}
+
+	packages := make([]PackageDetails, 0, len(parsedLockfile.Dependencies))
+
+	for _, lockPackage := range parsedLockfile.Dependencies {
+		packages = append(packages, PackageDetails{
+			Name:      lockPackage.Name,
+			Version:   lockPackage.Version,
+			Ecosystem: MavenEcosystem,
+		})
+	}
+
+	return packages, nil
+}

--- a/internal/lockfile/parse-maven-lock.go
+++ b/internal/lockfile/parse-maven-lock.go
@@ -15,7 +15,19 @@ type MavenLockDependency struct {
 	Version string   `xml:"version"`
 }
 
-func (mld MavenLockDependency) ResolveVersion(lockfile MavenLockFile) string {
+func (mld MavenLockDependency) parseResolvedVersion(version string) string {
+	versionRequirementReg := regexp.MustCompile(`[[(]?(.*?)(?:,|[)\]]|$)`)
+
+	results := versionRequirementReg.FindStringSubmatch(version)
+
+	if results == nil || results[1] == "" {
+		return "0"
+	}
+
+	return results[1]
+}
+
+func (mld MavenLockDependency) resolveVersionValue(lockfile MavenLockFile) string {
 	interpolationReg := regexp.MustCompile(`\${(.+)}`)
 
 	results := interpolationReg.FindStringSubmatch(mld.Version)
@@ -36,6 +48,12 @@ func (mld MavenLockDependency) ResolveVersion(lockfile MavenLockFile) string {
 	)
 
 	return "0"
+}
+
+func (mld MavenLockDependency) ResolveVersion(lockfile MavenLockFile) string {
+	version := mld.resolveVersionValue(lockfile)
+
+	return mld.parseResolvedVersion(version)
 }
 
 type MavenLockFile struct {

--- a/internal/lockfile/parse-maven-lock_test.go
+++ b/internal/lockfile/parse-maven-lock_test.go
@@ -96,5 +96,97 @@ func TestParseMavenLock_Interpolation(t *testing.T) {
 			Version:   "2.3.4",
 			Ecosystem: lockfile.MavenEcosystem,
 		},
+		{
+			Name:      "ranged-package",
+			Version:   "9.4.35.v20201120",
+			Ecosystem: lockfile.MavenEcosystem,
+		},
 	})
+}
+
+func TestMavenLockDependency_ResolveVersion(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Version string
+	}
+	type args struct {
+		lockfile lockfile.MavenLockFile
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		// 1.0: Soft requirement for 1.0. Use 1.0 if no other version appears earlier in the dependency tree.
+		{
+			name:   "",
+			fields: fields{Version: "1.0"},
+			args:   args{lockfile: lockfile.MavenLockFile{}},
+			want:   "1.0",
+		},
+		// [1.0]: Hard requirement for 1.0. Use 1.0 and only 1.0.
+		{
+			name:   "",
+			fields: fields{Version: "[1.0]"},
+			args:   args{lockfile: lockfile.MavenLockFile{}},
+			want:   "1.0",
+		},
+		// (,1.0]: Hard requirement for any version <= 1.0.
+		{
+			name:   "",
+			fields: fields{Version: "(,1.0]"},
+			args:   args{lockfile: lockfile.MavenLockFile{}},
+			want:   "0",
+		},
+		// [1.2,1.3]: Hard requirement for any version between 1.2 and 1.3 inclusive.
+		{
+			name:   "",
+			fields: fields{Version: "[1.2,1.3]"},
+			args:   args{lockfile: lockfile.MavenLockFile{}},
+			want:   "1.2",
+		},
+		// [1.0,2.0): 1.0 <= x < 2.0; Hard requirement for any version between 1.0 inclusive and 2.0 exclusive.
+		{
+			name:   "",
+			fields: fields{Version: "[1.0,2.0)"},
+			args:   args{lockfile: lockfile.MavenLockFile{}},
+			want:   "1.0",
+		},
+		// [1.5,): Hard requirement for any version greater than or equal to 1.5.
+		{
+			name:   "",
+			fields: fields{Version: "[1.5,)"},
+			args:   args{lockfile: lockfile.MavenLockFile{}},
+			want:   "1.5",
+		},
+		// (,1.0],[1.2,): Hard requirement for any version less than or equal to 1.0 than or greater than or equal to 1.2, but not 1.1.
+		{
+			name:   "",
+			fields: fields{Version: "(,1.0],[1.2,)"},
+			args:   args{lockfile: lockfile.MavenLockFile{}},
+			want:   "0",
+		},
+		// (,1.1),(1.1,): Hard requirement for any version except 1.1; for example because 1.1 has a critical vulnerability.
+		{
+			name:   "",
+			fields: fields{Version: "(,1.1),(1.1,)"},
+			args:   args{lockfile: lockfile.MavenLockFile{}},
+			want:   "0",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mld := lockfile.MavenLockDependency{
+				Version: tt.fields.Version,
+			}
+			if got := mld.ResolveVersion(tt.args.lockfile); got != tt.want {
+				t.Errorf("ResolveVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/lockfile/parse-maven-lock_test.go
+++ b/internal/lockfile/parse-maven-lock_test.go
@@ -1,0 +1,77 @@
+package lockfile_test
+
+import (
+	"osv-detector/internal/lockfile"
+	"testing"
+)
+
+func TestParseMavenLock_FileDoesNotExist(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseMavenLock("fixtures/maven/does-not-exist")
+
+	expectErrContaining(t, err, "could not read")
+	expectPackages(t, packages, []lockfile.PackageDetails{})
+}
+
+func TestParseMavenLock_Invalid(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseMavenLock("fixtures/maven/not-pom.txt")
+
+	expectErrContaining(t, err, "could not parse")
+	expectPackages(t, packages, []lockfile.PackageDetails{})
+}
+
+func TestParseMavenLock_NoPackages(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseMavenLock("fixtures/maven/empty.xml")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{})
+}
+
+func TestParseMavenLock_OnePackage(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseMavenLock("fixtures/maven/one-package.xml")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "maven-artifact",
+			Version:   "1.0.0",
+			Ecosystem: lockfile.MavenEcosystem,
+		},
+	})
+}
+
+func TestParseMavenLock_TwoPackages(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseMavenLock("fixtures/maven/two-packages.xml")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "netty-all",
+			Version:   "4.1.42.Final",
+			Ecosystem: lockfile.MavenEcosystem,
+		},
+		{
+			Name:      "slf4j-log4j12",
+			Version:   "1.7.25",
+			Ecosystem: lockfile.MavenEcosystem,
+		},
+	})
+}

--- a/internal/lockfile/parse-maven-lock_test.go
+++ b/internal/lockfile/parse-maven-lock_test.go
@@ -75,3 +75,26 @@ func TestParseMavenLock_TwoPackages(t *testing.T) {
 		},
 	})
 }
+
+func TestParseMavenLock_Interpolation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseMavenLock("fixtures/maven/interpolation.xml")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "mypackage",
+			Version:   "1.0.0",
+			Ecosystem: lockfile.MavenEcosystem,
+		},
+		{
+			Name:      "my.package",
+			Version:   "2.3.4",
+			Ecosystem: lockfile.MavenEcosystem,
+		},
+	})
+}

--- a/internal/lockfile/parse-maven-lock_test.go
+++ b/internal/lockfile/parse-maven-lock_test.go
@@ -46,7 +46,7 @@ func TestParseMavenLock_OnePackage(t *testing.T) {
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "maven-artifact",
+			Name:      "org.apache.maven:maven-artifact",
 			Version:   "1.0.0",
 			Ecosystem: lockfile.MavenEcosystem,
 		},
@@ -64,12 +64,12 @@ func TestParseMavenLock_TwoPackages(t *testing.T) {
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "netty-all",
+			Name:      "io.netty:netty-all",
 			Version:   "4.1.42.Final",
 			Ecosystem: lockfile.MavenEcosystem,
 		},
 		{
-			Name:      "slf4j-log4j12",
+			Name:      "org.slf4j:slf4j-log4j12",
 			Version:   "1.7.25",
 			Ecosystem: lockfile.MavenEcosystem,
 		},
@@ -87,17 +87,17 @@ func TestParseMavenLock_Interpolation(t *testing.T) {
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "mypackage",
+			Name:      "org.mine:mypackage",
 			Version:   "1.0.0",
 			Ecosystem: lockfile.MavenEcosystem,
 		},
 		{
-			Name:      "my.package",
+			Name:      "org.mine:my.package",
 			Version:   "2.3.4",
 			Ecosystem: lockfile.MavenEcosystem,
 		},
 		{
-			Name:      "ranged-package",
+			Name:      "org.mine:ranged-package",
 			Version:   "9.4.35.v20201120",
 			Ecosystem: lockfile.MavenEcosystem,
 		},

--- a/internal/lockfile/parse.go
+++ b/internal/lockfile/parse.go
@@ -24,6 +24,7 @@ var parsers = map[string]PackageDetailsParser{
 	"go.mod":            ParseGoLock,
 	"package-lock.json": ParseNpmLock,
 	"pnpm-lock.yaml":    ParsePnpmLock,
+	"pom.xml":           ParseMavenLock,
 	"requirements.txt":  ParseRequirementsTxt,
 	"yarn.lock":         ParseYarnLock,
 }

--- a/internal/lockfile/parse_test.go
+++ b/internal/lockfile/parse_test.go
@@ -46,6 +46,7 @@ func TestFindParser(t *testing.T) {
 		"composer.lock",
 		"Gemfile.lock",
 		"go.mod",
+		"pom.xml",
 		"requirements.txt",
 	}
 
@@ -87,6 +88,7 @@ func TestParse_FindsExpectedParsers(t *testing.T) {
 		"composer.lock",
 		"Gemfile.lock",
 		"go.mod",
+		"pom.xml",
 		"requirements.txt",
 	}
 


### PR DESCRIPTION
While I've done a bit of Java (mainly from my uni days), I've never done a lot with the ecosystem so didn't know much about how dependencies were actually managed other than them coming from Maven, and so I didn't really realise that Java / Maven doesn't actually have a lockfile.

This results in the all the standard caveats of not having a lockfile: there's no way of knowing the actual exact versions of libraries being used, so it's not possible to give a completely accurate report on what known vulnerabilities impact a project.

This doesn't mean this parser is useless, just that it's going to be the worst for "casual use" (e.g. "just scan my project") as for best results developers are going to have to craft a detailed `pom.xml` that specifies all their dependencies in as exact versions as possible.

I imagine it would be somewhat straightforward to write a script that builds this based on the output of `mvn dependency:tree`, and users of plugins like https://github.com/vandmo/dependency-lock-maven-plugin should be fine so long as they're using the `pom.xml` output format.

Having this parser also means the ecosystem is known now, so the detector will be able to support it once #13 is landed.

Resolves #33