### PR TITLE
fix: exit with "generic error" code instead of "vuls. found" code when no valid path is provided

### DIFF
--- a/main.go
+++ b/main.go
@@ -199,7 +199,7 @@ func run() int {
 			"You must provide at least one path to either a lockfile or a directory containing a lockfile (see --help for usage and flags)\n",
 		)
 
-		return 1
+		return 127
 	}
 
 	exitCode := 0


### PR DESCRIPTION
We exit with code `1` when there is at least one affected vulnerability, which isn't the case for this situation so we should instead exit with code `127`.