### PR TITLE
feat: support ignoring vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ passed:
           "name": "github.com/BurntSushi/toml",
           "version": "1.0.0",
           "ecosystem": "Go",
-          "vulnerabilities": []
+          "vulnerabilities": [],
+          "ignored": []
         }
       ]
     },
@@ -110,7 +111,8 @@ passed:
           "name": "wrappy",
           "version": "1.0.2",
           "ecosystem": "npm",
-          "vulnerabilities": []
+          "vulnerabilities": [],
+          "ignored": []
         }
       ]
     }

--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ osv-detector --cache-all-databases
 This can be useful if you're planning to run the detector over a number of
 lockfiles in bulk.
 
+By default, the detector will output the results to `stdout` as plain text, and
+exit with an error code of `1` if at least one vulnerability is found.
+
+you can use the `--ignore` flag to have the detector ignore a particular
+vulnerability - ignored vulnerabilities won't be included in the text output,
+and won't be counted when determining the code to exit with:
+
+```
+osv-detector --ignore GHSA-896r-f27r-55mw package-lock.json
+
+# you can pass multiple ignores
+osv-detector --ignore GHSA-896r-f27r-55mw --ignore GHSA-74fj-2j2h-c42q package-lock.json
+```
+
 You can use the `--json` flag to have the detector output its results as JSON:
 
 ```shell

--- a/internal/database/vulnerabilities.go
+++ b/internal/database/vulnerabilities.go
@@ -1,6 +1,10 @@
 package database
 
-import "osv-detector/internal"
+import (
+	"encoding/json"
+	"fmt"
+	"osv-detector/internal"
+)
 
 func (db *OSVDatabase) Vulnerabilities(includeWithdrawn bool) []OSV {
 	if includeWithdrawn {
@@ -47,4 +51,22 @@ func (db *OSVDatabase) VulnerabilitiesAffectingPackage(pkg internal.PackageDetai
 	}
 
 	return vulnerabilities
+}
+
+// MarshalJSON ensures that if there are no vulnerabilities,
+// an empty array is used as the value instead of "null"
+func (vs Vulnerabilities) MarshalJSON() ([]byte, error) {
+	if len(vs) == 0 {
+		return []byte("[]"), nil
+	}
+
+	type innerVulnerabilities Vulnerabilities
+
+	out, err := json.Marshal(innerVulnerabilities(vs))
+
+	if err != nil {
+		return out, fmt.Errorf("%w", err)
+	}
+
+	return out, nil
 }

--- a/internal/database/vulnerabilities_test.go
+++ b/internal/database/vulnerabilities_test.go
@@ -1,6 +1,7 @@
 package database_test
 
 import (
+	"encoding/json"
 	"osv-detector/internal/database"
 	"testing"
 )
@@ -121,6 +122,61 @@ func TestVulnerabilities_Includes(t *testing.T) {
 
 			if got := tt.vs.Includes(tt.args.osv); got != tt.want {
 				t.Errorf("Includes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVulnerabilities_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	osv := database.OSV{ID: "GHSA-1"}
+	asJSON, err := json.Marshal(osv)
+
+	if err != nil {
+		t.Fatalf("Unable to marshal osv to JSON: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		vs   database.Vulnerabilities
+		want string
+	}{
+		{
+			name: "",
+			vs:   nil,
+			want: "[]",
+		},
+		{
+			name: "",
+			vs:   database.Vulnerabilities(nil),
+			want: "[]",
+		},
+		{
+			name: "",
+			vs:   database.Vulnerabilities{osv},
+			want: "[" + string(asJSON) + "]",
+		},
+		{
+			name: "",
+			vs:   database.Vulnerabilities{osv, osv},
+			want: "[" + string(asJSON) + "," + string(asJSON) + "]",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tt.vs.MarshalJSON()
+			if err != nil {
+				t.Errorf("MarshalJSON() error = %v", err)
+
+				return
+			}
+
+			if gotStr := string(got); gotStr != tt.want {
+				t.Errorf("MarshalJSON() got = %v, want %v", gotStr, tt.want)
 			}
 		})
 	}

--- a/internal/reporter/report.go
+++ b/internal/reporter/report.go
@@ -13,6 +13,7 @@ type PackageDetailsWithVulnerabilities struct {
 	internal.PackageDetails
 
 	Vulnerabilities database.Vulnerabilities `json:"vulnerabilities"`
+	Ignored         database.Vulnerabilities `json:"ignored"`
 }
 
 type Report struct {

--- a/internal/reporter/report.go
+++ b/internal/reporter/report.go
@@ -36,6 +36,20 @@ func (r Report) countKnownVulnerabilities() int {
 	return knownVulnerabilitiesCount
 }
 
+func (r Report) HasIgnoredVulnerabilities() bool {
+	return r.countIgnoredVulnerabilities() > 0
+}
+
+func (r Report) countIgnoredVulnerabilities() int {
+	ignoredVulnerabilitiesCount := 0
+
+	for _, pkg := range r.Packages {
+		ignoredVulnerabilitiesCount += len(pkg.Ignored)
+	}
+
+	return ignoredVulnerabilitiesCount
+}
+
 func (r Report) formatLineByLine() string {
 	lines := make([]string, 0, len(r.Packages))
 
@@ -70,23 +84,49 @@ func Form(count int, singular, plural string) string {
 	return plural
 }
 
-func (r Report) ToString() string {
-	count := r.countKnownVulnerabilities()
+func (r Report) describeIgnores() string {
+	count := r.countIgnoredVulnerabilities()
 
 	if count == 0 {
-		return fmt.Sprintf("%s\n", color.GreenString("  no known vulnerabilities found"))
+		return ""
+	}
+
+	return color.YellowString(
+		" (%d %s ignored)",
+		count,
+		Form(count, "was", "were"),
+	)
+}
+
+func (r Report) ToString() string {
+	count := r.countKnownVulnerabilities()
+	ignoreMsg := r.describeIgnores()
+	word := "known"
+
+	if ignoreMsg != "" {
+		word = "new"
+	}
+
+	if count == 0 {
+		return fmt.Sprintf(
+			"  %s%s\n",
+			color.GreenString("no %s vulnerabilities found", word),
+			ignoreMsg,
+		)
 	}
 
 	out := r.formatLineByLine()
 	out += "\n"
 
-	out += fmt.Sprintf("\n  %s\n",
+	out += fmt.Sprintf("\n  %s%s\n",
 		color.RedString(
-			"%d known %s found in %s",
+			"%d %s %s found in %s",
 			count,
+			word,
 			Form(count, "vulnerability", "vulnerabilities"),
 			r.FilePath,
 		),
+		ignoreMsg,
 	)
 
 	return out


### PR DESCRIPTION
This adds support for being able to ignore vulnerabilities so that `osv-detector` does not exit with a non-zero exit code if the ignored vulnerabilities are the only ones present.

Ignores are applied to all packages being checked which should be enough as OSVs only apply to one package from what I've seen (though they can apply to the same package across different ecosystems, but that should be fine).

We _don't_ check if the ignores provided map to known vulnerabilities nor that all of the vulnerabilities that are expected to be ignored are present - while I'd like to, I think it'd be very tricky because you'd need to check that the ignored vulnerability isn't in _any_ of the packages specified in _all_ of the lockfiles (this is compounded if you add config files into the mix, because those will be applied per lockfile directory)

When outputting as text, ignored vulnerabilities are omitted - this is based off my experiences with [`audit-app`](https://github.com/G-Rath/audit-app), where people were confused by the fact that the tool would still include ignored vulnerabilities in the output (in particular when they were trying to ignore everything):

```
lockfile/fixtures/npm on  support-ignores [$?] on ☁️  (ap-southeast-2)
❯ osv-detector-t --ignore GHSA-566m-qj78-rww5 --parse-as package-lock.json nested-dependencies.v2.json
nested-dependencies.v2.json: found 5 packages
  Loading OSV databases for the following ecosystems:
    npm (2399 vulnerabilities, including withdrawn - last updated Mon, 09 May 2022 19:15:03 GMT)

  postcss@7.0.16 is affected by the following vulnerabilities:
    GHSA-hwj9-h5mp-3pm3: Regular Expression Denial of Service in postcss (https://github.com/advisories/GHSA-hwj9-h5mp-3pm3)

  1 new vulnerability found in nested-dependencies.v2.json (2 were ignored)
```

<img width="762" alt="image" src="https://user-images.githubusercontent.com/3151613/167484073-3ec55cb5-21e0-4fcc-b70a-d3e4ed71b21c.png">

When outputting as JSON, ignored vulnerabilities are listed in a new `ignored` array - that way automated tools can still see details about the ignored vulnerabilities (e.g. they could check the modified time to see if an ignored vulnerability has been changed), and should also be able to use that to check if any ignores are missing.

This'll be followed up with support for config so that projects can record and track their ignores more easily.

~(I still need to do the documentation for this)~

Resolves #6