### PR TITLE
feat: support config file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
 internal/*/fixtures/pnpm/*.yaml
+internal/configer/fixtures/ext-yaml-invalid/*.yaml
+internal/configer/fixtures/ext-yml-invalid/*.yml

--- a/README.md
+++ b/README.md
@@ -137,6 +137,31 @@ passed:
 Errors are always sent to `stderr` as plain text, even if the `--json` flag is
 passed.
 
+### Config files
+
+The detector supports loading ignores from a YAML file, which can be useful for
+tracking ignored vulnerabilities per-project:
+
+```yaml
+ignore:
+  - GHSA-4 # "Prototype pollution in xyz"
+  - GHSA-5 # "RegExp DDoS in abc"
+  - GHSA-6 # "Command injection in hjk"
+```
+
+By default, the detector will look for a `.osv-detector.yaml` or
+`.osv-detector.yml` in the same folder as the current lockfile it's checking,
+and will _merge_ the config with any flags being passed.
+
+You can also provide a path to a specific config file that will be used for all
+lockfiles being checked with the `--config` flag:
+
+```shell
+osv-detector --config ruby-ignores.yml path/to/my/first-ruby-project path/to/my/second-ruby-project
+```
+
+You can disable loading any configs with the `--no-config` flag.
+
 ### Auxiliary output commands
 
 The detector supports a few auxiliary commands that have it output information

--- a/internal/configer/fixtures/ext-yaml-invalid/.osv-detector.yaml
+++ b/internal/configer/fixtures/ext-yaml-invalid/.osv-detector.yaml
@@ -1,0 +1,4 @@
+ignore
+  - GHSA-4 # "Prototype pollution in xyz"
+  - GHSA-5 # "RegExp DDoS in abc"
+  - GHSA-6 # "Command injection in hjk"

--- a/internal/configer/fixtures/ext-yaml/.osv-detector.yaml
+++ b/internal/configer/fixtures/ext-yaml/.osv-detector.yaml
@@ -1,0 +1,4 @@
+ignore:
+  - GHSA-4 # "Prototype pollution in xyz"
+  - GHSA-5 # "RegExp DDoS in abc"
+  - GHSA-6 # "Command injection in hjk"

--- a/internal/configer/fixtures/ext-yml-invalid/.osv-detector.yml
+++ b/internal/configer/fixtures/ext-yml-invalid/.osv-detector.yml
@@ -1,0 +1,4 @@
+ignore
+  - GHSA-4 # "Prototype pollution in xyz"
+  - GHSA-5 # "RegExp DDoS in abc"
+  - GHSA-6 # "Command injection in hjk"

--- a/internal/configer/fixtures/ext-yml/.osv-detector.yml
+++ b/internal/configer/fixtures/ext-yml/.osv-detector.yml
@@ -1,0 +1,4 @@
+ignore:
+  - GHSA-1 # "Prototype pollution in xyz"
+  - GHSA-2 # "RegExp DDoS in abc"
+  - GHSA-3 # "Command injection in hjk"

--- a/internal/configer/fixtures/invalid/.osv-detector.yml
+++ b/internal/configer/fixtures/invalid/.osv-detector.yml
@@ -1,0 +1,4 @@
+ignore
+  - GHSA-4 # "Prototype pollution in xyz"
+  - GHSA-5 # "RegExp DDoS in abc"
+  - GHSA-6 # "Command injection in hjk"

--- a/internal/configer/fixtures/invalid/.osv-detector.yml
+++ b/internal/configer/fixtures/invalid/.osv-detector.yml
@@ -1,4 +1,0 @@
-ignore
-  - GHSA-4 # "Prototype pollution in xyz"
-  - GHSA-5 # "RegExp DDoS in abc"
-  - GHSA-6 # "Command injection in hjk"

--- a/internal/configer/load.go
+++ b/internal/configer/load.go
@@ -1,0 +1,66 @@
+package configer
+
+import (
+	"errors"
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"os"
+)
+
+type Config struct {
+	FilePath string
+	Ignore   []string `yaml:"ignore"`
+}
+
+// Find attempts to locate & load a Config using the default name (".osv-detector")
+func Find(pathToDirectory string) (Config, error) {
+	var config Config
+	var err error
+
+	configName := ".osv-detector"
+
+	config, err = Load(pathToDirectory + "/" + configName + ".yml")
+
+	if err == nil {
+		return config, nil
+	}
+
+	if !errors.Is(err, os.ErrNotExist) {
+		return config, err
+	}
+
+	config, err = Load(pathToDirectory + "/" + configName + ".yaml")
+
+	if err == nil {
+		return config, nil
+	}
+
+	if !errors.Is(err, os.ErrNotExist) {
+		return config, err
+	}
+
+	// if we couldn't find a config at all,
+	// we want to return an empty Config
+	// that doesn't have FilePath set
+	return Config{}, nil
+}
+
+func Load(pathToConfig string) (Config, error) {
+	var config Config
+
+	config.FilePath = pathToConfig
+
+	configContents, err := os.ReadFile(pathToConfig)
+
+	if err != nil {
+		return config, fmt.Errorf("could not read %s: %w", pathToConfig, err)
+	}
+
+	err = yaml.Unmarshal(configContents, &config)
+
+	if err != nil {
+		return config, fmt.Errorf("could not read %s: %w", pathToConfig, err)
+	}
+
+	return config, nil
+}

--- a/internal/configer/load_test.go
+++ b/internal/configer/load_test.go
@@ -1,0 +1,107 @@
+package configer_test
+
+import (
+	"osv-detector/internal/configer"
+	"reflect"
+	"testing"
+)
+
+func TestFind_NoConfig(t *testing.T) {
+	t.Parallel()
+
+	config, err := configer.Find("fixtures/no-config")
+
+	if err != nil {
+		t.Errorf("Find() error = %v, expected nothing", err)
+	}
+
+	if config.FilePath != "" {
+		t.Errorf("Find() config.FilePath = %s, expected empty", config.FilePath)
+	}
+
+	if l := len(config.Ignore); l > 0 {
+		t.Errorf("Find() config.Ignore = %d, expected empty", l)
+	}
+}
+
+func TestFind_ExtYml(t *testing.T) {
+	t.Parallel()
+
+	expectedIgnores := []string{"GHSA-1", "GHSA-2", "GHSA-3"}
+	expectedFilePath := "fixtures/ext-yml/.osv-detector.yml"
+
+	config, err := configer.Find("fixtures/ext-yml")
+
+	if err != nil {
+		t.Errorf("Find() error = %v, expected nothing", err)
+	}
+
+	if config.FilePath != expectedFilePath {
+		t.Errorf("Find() config.FilePath = %s, expected %s", config.FilePath, expectedFilePath)
+	}
+
+	if !reflect.DeepEqual(config.Ignore, expectedIgnores) {
+		t.Errorf("Find() config.Ignore = %v, expected empty", expectedIgnores)
+	}
+}
+
+func TestFind_ExtYml_Invalid(t *testing.T) {
+	t.Parallel()
+
+	expectedFilePath := "fixtures/ext-yml-invalid/.osv-detector.yml"
+
+	config, err := configer.Find("fixtures/ext-yml-invalid")
+
+	if err == nil {
+		t.Errorf("Find() did not error, which was unexpected")
+	}
+
+	if config.FilePath != expectedFilePath {
+		t.Errorf("Find() config.FilePath = %s, expected %s", config.FilePath, expectedFilePath)
+	}
+
+	if l := len(config.Ignore); l > 0 {
+		t.Errorf("Find() config.Ignore = %d, expected empty", l)
+	}
+}
+
+func TestFind_ExtYaml(t *testing.T) {
+	t.Parallel()
+
+	expectedIgnores := []string{"GHSA-4", "GHSA-5", "GHSA-6"}
+	expectedFilePath := "fixtures/ext-yaml/.osv-detector.yaml"
+
+	config, err := configer.Find("fixtures/ext-yaml")
+
+	if err != nil {
+		t.Errorf("Find() error = %v, expected nothing", err)
+	}
+
+	if config.FilePath != expectedFilePath {
+		t.Errorf("Find() config.FilePath = %s, expected %s", config.FilePath, expectedFilePath)
+	}
+
+	if !reflect.DeepEqual(config.Ignore, expectedIgnores) {
+		t.Errorf("Find() config.Ignore = %v, expected empty", expectedIgnores)
+	}
+}
+
+func TestFind_ExtYaml_Invalid(t *testing.T) {
+	t.Parallel()
+
+	expectedFilePath := "fixtures/ext-yaml-invalid/.osv-detector.yaml"
+
+	config, err := configer.Find("fixtures/ext-yaml-invalid")
+
+	if err == nil {
+		t.Errorf("Find() did not error, which was unexpected")
+	}
+
+	if config.FilePath != expectedFilePath {
+		t.Errorf("Find() config.FilePath = %s, expected %s", config.FilePath, expectedFilePath)
+	}
+
+	if l := len(config.Ignore); l > 0 {
+		t.Errorf("Find() config.Ignore = %d, expected empty", l)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -206,6 +206,7 @@ func run() int {
 	offline := flag.Bool("offline", false, "Perform checks using only the cached databases on disk")
 	parseAs := flag.String("parse-as", "", "Name of a supported lockfile to parse the input files as")
 	configPath := flag.String("config", "", "Path to a config file to use for all lockfiles")
+	noConfig := flag.Bool("no-config", false, "Disable loading of any config files")
 	printVersion := flag.Bool("version", false, "Print version information")
 	listEcosystems := flag.Bool("list-ecosystems", false, "List all of the known ecosystems that are supported by the detector")
 	listPackages := flag.Bool("list-packages", false, "List the packages that are parsed from the input files")
@@ -272,7 +273,7 @@ This flag can be passed multiple times to ignore different vulnerabilities`)
 
 	var config configer.Config
 
-	if *configPath != "" {
+	if !*noConfig && *configPath != "" {
 		con, err := configer.Load(*configPath)
 
 		if err != nil {
@@ -291,7 +292,7 @@ This flag can be passed multiple times to ignore different vulnerabilities`)
 			r.PrintText("\n")
 		}
 
-		if *configPath == "" {
+		if !*noConfig && *configPath == "" {
 			base := path.Dir(pathToLock)
 			con, err := configer.Find(base)
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fatih/color"
 	"os"
 	"osv-detector/internal"
+	"osv-detector/internal/configer"
 	"osv-detector/internal/database"
 	"osv-detector/internal/lockfile"
 	"osv-detector/internal/reporter"
@@ -185,11 +186,26 @@ func (s *stringsFlag) Set(value string) error {
 	return nil
 }
 
+func allIgnores(global, local []string) []string {
+	ignores := make(
+		[]string,
+		0,
+		// len cannot return negative numbers, but the types can't reflect that
+		uint64(len(global))+uint64(len(local)),
+	)
+
+	ignores = append(ignores, global...)
+	ignores = append(ignores, local...)
+
+	return ignores
+}
+
 func run() int {
 	var ignores stringsFlag
 
 	offline := flag.Bool("offline", false, "Perform checks using only the cached databases on disk")
 	parseAs := flag.String("parse-as", "", "Name of a supported lockfile to parse the input files as")
+	configPath := flag.String("config", "", "Path to a config file to use for all lockfiles")
 	printVersion := flag.Bool("version", false, "Print version information")
 	listEcosystems := flag.Bool("list-ecosystems", false, "List all of the known ecosystems that are supported by the detector")
 	listPackages := flag.Bool("list-packages", false, "List the packages that are parsed from the input files")
@@ -254,9 +270,39 @@ This flag can be passed multiple times to ignore different vulnerabilities`)
 
 	exitCode := 0
 
+	var config configer.Config
+
+	if *configPath != "" {
+		con, err := configer.Load(*configPath)
+
+		if err != nil {
+			r.PrintError(fmt.Sprintf("Error, %s\n", err))
+
+			return 127
+		}
+
+		config = con
+	}
+
 	for i, pathToLock := range pathsToLocks {
+		config := config
+
 		if i >= 1 {
 			r.PrintText("\n")
+		}
+
+		if *configPath == "" {
+			base := path.Dir(pathToLock)
+			con, err := configer.Find(base)
+
+			if err != nil {
+				r.PrintError(fmt.Sprintf("Error, %s\n", err))
+				exitCode = 127
+
+				continue
+			}
+
+			config = con
 		}
 
 		lockf, err := lockfile.Parse(pathToLock, *parseAs)
@@ -281,6 +327,18 @@ This flag can be passed multiple times to ignore different vulnerabilities`)
 			continue
 		}
 
+		// an empty FilePath means we didn't load a config
+		if config.FilePath != "" {
+			r.PrintText(fmt.Sprintf(
+				"  Using config at %s (%s)\n",
+				color.MagentaString(config.FilePath),
+				color.YellowString("%d %s",
+					len(config.Ignore),
+					reporter.Form(len(config.Ignore), "ignore", "ignores"),
+				),
+			))
+		}
+
 		dbs, err := loadEcosystemDatabases(r, lockf.Packages.Ecosystems(), *offline)
 
 		if err != nil {
@@ -290,7 +348,7 @@ This flag can be passed multiple times to ignore different vulnerabilities`)
 			continue
 		}
 
-		report := dbs.check(lockf, ignores)
+		report := dbs.check(lockf, allIgnores(config.Ignore, ignores))
 
 		r.PrintResult(report)
 


### PR DESCRIPTION
This adds support for config files, which can be used for specifying ignores in a way that can be tracked e.g. in version control.

Right now the only valid config option is `ignore` which takes an array of OSV ids to be ignored (matching the `--ignore` flag), since that's the flag we have that makes sense to configure per-project, but I think this could be useful in future for supporting custom databases.

Config is merged with any flags, meaning if you specify ignores in both the config & as flags they'll all be taken (rather than just the ignores from flags or the config). You can use `--no-config` to tell the detector to not load any config files.

The config must be in YAML format, and the default config file is `.osv-detector.yaml` & `.osv-detector.yml`.