### PR TITLE
ci: pin `goreleaser` to specific version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: 1.8.3
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Releases have been failing for an unknown reason:

```
   ⨯ release failed after 170.51s error=scm releases: failed to publish artifacts: PATCH https://api.github.com/repos/G-Rath/osv-detector/releases/0: 404 Not Found []
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.9.0/x64/goreleaser' failed with exit code 1
```

* https://github.com/G-Rath/osv-detector/runs/6513401634?check_suite_focus=true
* https://github.com/G-Rath/osv-detector/runs/6513046522?check_suite_focus=true
* https://github.com/G-Rath/osv-detector/runs/6513271249?check_suite_focus=true

I can't find anything on the `goreleaser` GitHub and I've not changed anything about my GitHub but the last successful release was done using `goreleaser` v1.8.3 whereas now we're using (and failing on) v1.9.0 so going to see if the issue still happens in the previous version.