### PR TITLE
refactor: move reporter functions into `reporter` package

### DIFF
--- a/internal/reporter/report_test.go
+++ b/internal/reporter/report_test.go
@@ -97,6 +97,143 @@ func TestReport_HasKnownVulnerabilities(t *testing.T) {
 	}
 }
 
+func TestReport_HasIgnoredVulnerabilities(t *testing.T) {
+	t.Parallel()
+
+	packageDetails := internal.PackageDetails{
+		Name:      "addr2line",
+		Version:   "0.15.2",
+		Ecosystem: lockfile.CargoEcosystem,
+	}
+	type fields struct {
+		Lockfile lockfile.Lockfile
+		Packages []reporter.PackageDetailsWithVulnerabilities
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "no packages",
+			fields: fields{
+				Lockfile: lockfile.Lockfile{},
+				Packages: []reporter.PackageDetailsWithVulnerabilities{},
+			},
+			want: false,
+		},
+		{
+			name: "no vulnerabilities",
+			fields: fields{
+				Lockfile: lockfile.Lockfile{},
+				Packages: []reporter.PackageDetailsWithVulnerabilities{
+					{
+						PackageDetails:  packageDetails,
+						Vulnerabilities: []database.OSV{},
+					},
+					{
+						PackageDetails:  packageDetails,
+						Vulnerabilities: []database.OSV{},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "one package with one vulnerability",
+			fields: fields{
+				Lockfile: lockfile.Lockfile{},
+				Packages: []reporter.PackageDetailsWithVulnerabilities{
+					{
+						PackageDetails:  packageDetails,
+						Vulnerabilities: []database.OSV{{ID: "1"}},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "one package with one ignored vulnerability",
+			fields: fields{
+				Lockfile: lockfile.Lockfile{},
+				Packages: []reporter.PackageDetailsWithVulnerabilities{
+					{
+						PackageDetails:  packageDetails,
+						Vulnerabilities: []database.OSV{},
+						Ignored:         []database.OSV{{ID: "1"}},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "multiple packages, with one with a vulnerability",
+			fields: fields{
+				Lockfile: lockfile.Lockfile{},
+				Packages: []reporter.PackageDetailsWithVulnerabilities{
+					{
+						PackageDetails:  packageDetails,
+						Vulnerabilities: []database.OSV{},
+					},
+					{
+						PackageDetails:  packageDetails,
+						Vulnerabilities: []database.OSV{{ID: "1"}},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "multiple packages, with one with a ignored vulnerability",
+			fields: fields{
+				Lockfile: lockfile.Lockfile{},
+				Packages: []reporter.PackageDetailsWithVulnerabilities{
+					{
+						PackageDetails:  packageDetails,
+						Vulnerabilities: []database.OSV{},
+					},
+					{
+						PackageDetails: packageDetails,
+						Ignored:        []database.OSV{{ID: "1"}},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "multiple packages, with one with a vulnerability and one ignored",
+			fields: fields{
+				Lockfile: lockfile.Lockfile{},
+				Packages: []reporter.PackageDetailsWithVulnerabilities{
+					{
+						PackageDetails:  packageDetails,
+						Vulnerabilities: []database.OSV{{ID: "1"}},
+					},
+					{
+						PackageDetails:  packageDetails,
+						Vulnerabilities: []database.OSV{{ID: "1"}},
+						Ignored:         []database.OSV{{ID: "2"}},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := reporter.Report{
+				Lockfile: tt.fields.Lockfile,
+				Packages: tt.fields.Packages,
+			}
+			if got := r.HasIgnoredVulnerabilities(); got != tt.want {
+				t.Errorf("HasIgnoredVulnerabilities() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestReport_ToString_NoVulnerabilities(t *testing.T) {
 	t.Parallel()
 

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -2,8 +2,12 @@ package reporter
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"github.com/fatih/color"
 	"io"
+	"osv-detector/pkg/database"
+	"osv-detector/pkg/lockfile"
 )
 
 type Reporter struct {
@@ -71,4 +75,24 @@ func (r *Reporter) PrintJSONResults() {
 	}
 
 	fmt.Fprint(r.stdout, string(out))
+}
+
+func (r *Reporter) PrintDatabaseLoadErr(err error) {
+	msg := err.Error()
+
+	if errors.Is(err, database.ErrOfflineDatabaseNotFound) {
+		msg = color.RedString("no local version of the database was found, and --offline flag was set")
+	}
+
+	r.PrintError(fmt.Sprintf(" %s\n", color.RedString("failed: %s", msg)))
+}
+
+func (r *Reporter) PrintKnownEcosystems() {
+	ecosystems := lockfile.KnownEcosystems()
+
+	r.PrintText("The detector supports parsing for the following ecosystems:\n")
+
+	for _, ecosystem := range ecosystems {
+		r.PrintText(fmt.Sprintf("  %s\n", ecosystem))
+	}
 }


### PR DESCRIPTION
These arguably make sense to belong to `reporter`, and this means we can test them + reduce the size of `main.go` a little.

Have also snuck a test in to get us to 100% coverage of the `reporter` package 🎉 