### PR TITLE
fix: use `name` and `version` properties if present when parsing `pnpm.yaml` locks

### DIFF
--- a/pkg/lockfile/fixtures/pnpm/tarball.yaml
+++ b/pkg/lockfile/fixtures/pnpm/tarball.yaml
@@ -1,0 +1,14 @@
+lockfileVersion: 5.3
+
+specifiers:
+  '@my-org/my-package': https://gitlab.my-org.org/api/v4/projects/1/packages/npm/@my-org/my-package/-/@my-org/my-package-3.2.3.tgz
+
+devDependencies:
+  '@my-org/my-package': '@gitlab.my-org.org/api/v4/projects/1/packages/npm/@my-org/my-package/-/@my-org/my-package-3.2.3.tgz'
+
+packages:
+  '@gitlab.my-org.org/api/v4/projects/1/packages/npm/@my-org/my-package/-/@my-org/my-package-3.2.3.tgz':
+    resolution: {tarball: https://gitlab.my-org.org/api/v4/projects/1/packages/npm/@my-org/my-package/-/@my-org/my-package-3.2.3.tgz}
+    name: '@my-org/my-package'
+    version: 3.2.3
+    dev: true

--- a/pkg/lockfile/parse-pnpm-lock.go
+++ b/pkg/lockfile/parse-pnpm-lock.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 )
 
-type PnpmLockPackage struct{}
+type PnpmLockPackage struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
 
 type PnpmLockfile struct {
 	Version  float64                    `yaml:"lockfileVersion"`
@@ -57,8 +60,20 @@ func extractPnpmPackageNameAndVersion(dependencyPath string) (string, string) {
 func parsePnpmLock(lockfile PnpmLockfile) []PackageDetails {
 	packages := make([]PackageDetails, 0, len(lockfile.Packages))
 
-	for s := range lockfile.Packages {
+	for s, pkg := range lockfile.Packages {
 		name, version := extractPnpmPackageNameAndVersion(s)
+
+		// "name" is only present if it's not in the dependency path and takes
+		// priority over whatever name we think we've extracted (if any)
+		if pkg.Name != "" {
+			name = pkg.Name
+		}
+
+		// "version" is only present if it's not in the dependency path and takes
+		// priority over whatever version we think we've extracted (if any)
+		if pkg.Version != "" {
+			version = pkg.Version
+		}
 
 		if name == "" || version == "" {
 			continue

--- a/pkg/lockfile/parse-pnpm-lock_test.go
+++ b/pkg/lockfile/parse-pnpm-lock_test.go
@@ -281,6 +281,25 @@ func TestParsePnpmLock_MultipleVersions(t *testing.T) {
 	})
 }
 
+func TestParsePnpmLock_Tarball(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/tarball.yaml")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "@my-org/my-package",
+			Version:   "3.2.3",
+			Ecosystem: lockfile.PnpmEcosystem,
+			Commit:    "",
+		},
+	})
+}
+
 func TestParsePnpmLock_Exotic(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When researching how `pnpm` represents git dependencies in it's lock to support extracting commits, I found out a bit more on how the dependencies paths work.

Turns out `pnpm` captures the `name` and `version` within the dependency path if possible, otherwise it includes them as a property - so if either of those properties are present we should favor them over whatever we extract from the dependency path.

This has also highlighted that this parser is probably the most inaccurate, but I'm not too fussed because it should only be falling over on exotic cases and I've not got a lot of easy reference to confirm what is and isn't correct so for now I'll have to rely on people opening issues if they find something is not being parsed correctly.