### PR TITLE
feat: support commits in csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ however it currently can produce false negatives for some ecosystems.
 > While the API supports commits, the detector currently has limited support for
 > extracting them - only the `composer.lock`, `Gemfile.lock`,
 > `package-lock.json`, `yarn.lock`, & `pnpm.yaml` parsers include commit details
+>
+> See [this section](#passing-arbitrary-package-details-advanced-usage) for how
+> you can provide the detector with arbitrary commits to check
 
 You cannot use the API in `--offline` mode, but you can use both the offline
 databases and the API together; the detector will remove any duplicate results.
@@ -216,7 +219,12 @@ cannot contain a header. The `ecosystem` does _not_ have to be one listed by the
 detector as known, meaning you can use any ecosystem that
 [osv.dev](https://osv.dev/) provides.
 
-> Currently, you cannot pass in a commit
+If you don't provide an ecosystem, then the `version` column is expected to be a
+commit. In this case, the `package` column is decorative as only the commit is
+passed to the API.
+
+> Remember to tell the detector to use the `osv.dev` API via the `--use-api`
+> flag if you're wanting to check commits!
 
 You can also omit the version to have the detector list all known
 vulnerabilities in the loaded database that apply to the given package:

--- a/internal/types.go
+++ b/internal/types.go
@@ -4,7 +4,7 @@ type PackageDetails struct {
 	Name      string    `json:"name"`
 	Version   string    `json:"version"`
 	Commit    string    `json:"commit,omitempty"`
-	Ecosystem Ecosystem `json:"ecosystem"`
+	Ecosystem Ecosystem `json:"ecosystem,omitempty"`
 }
 
 type Ecosystem string

--- a/pkg/lockfile/csv.go
+++ b/pkg/lockfile/csv.go
@@ -11,26 +11,37 @@ import (
 )
 
 var errCSVRecordNotEnoughFields = errors.New("not enough fields (missing at least ecosystem and package name)")
-var errCSVRecordMissingEcosystemField = errors.New("field 1 is empty (must be the name of an ecosystem)")
 var errCSVRecordMissingPackageField = errors.New("field 2 is empty (must be the name of a package)")
+var errCSVRecordMissingCommitField = errors.New("field 3 is empty (must be a commit)")
 
 func fromCSVRecord(lines []string) (PackageDetails, error) {
 	if len(lines) < 2 {
 		return PackageDetails{}, errCSVRecordNotEnoughFields
 	}
 
-	if lines[0] == "" {
-		return PackageDetails{}, errCSVRecordMissingEcosystemField
+	ecosystem := Ecosystem(lines[0])
+	name := lines[1]
+	version := lines[2]
+	commit := ""
+
+	if ecosystem == "" {
+		if version == "" {
+			return PackageDetails{}, errCSVRecordMissingCommitField
+		}
+
+		commit = version
+		version = ""
 	}
 
-	if lines[1] == "" {
+	if name == "" {
 		return PackageDetails{}, errCSVRecordMissingPackageField
 	}
 
 	return PackageDetails{
-		Name:      lines[1],
-		Version:   lines[2],
-		Ecosystem: Ecosystem(lines[0]),
+		Name:      name,
+		Version:   version,
+		Ecosystem: ecosystem,
+		Commit:    commit,
 	}, nil
 }
 

--- a/pkg/lockfile/csv_test.go
+++ b/pkg/lockfile/csv_test.go
@@ -99,6 +99,34 @@ func TestFromCSVRows(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "",
+			args: args{
+				filePath: "-",
+				parseAs:  "-",
+				rows: []string{
+					"NuGet,Yarp.ReverseProxy,",
+					",vue,bb253db0b3e17124b6d1fe93fbf2db35470a1347",
+				},
+			},
+			want: lockfile.Lockfile{
+				FilePath: "-",
+				ParsedAs: "-",
+				Packages: []lockfile.PackageDetails{
+					{
+						Name:      "Yarp.ReverseProxy",
+						Version:   "",
+						Ecosystem: "NuGet",
+					},
+					{
+						Name:      "vue",
+						Version:   "",
+						Ecosystem: "",
+						Commit:    "bb253db0b3e17124b6d1fe93fbf2db35470a1347",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -151,7 +179,31 @@ func TestFromCSVRows_Errors(t *testing.T) {
 					",,",
 				},
 			},
-			wantErrMsg: "row 2: field 1 is empty (must be the name of an ecosystem)",
+			wantErrMsg: "row 2: field 3 is empty (must be a commit)",
+		},
+		{
+			name: "",
+			args: args{
+				filePath: "",
+				parseAs:  "",
+				rows: []string{
+					"crates.io,addr2line,",
+					"npm,,",
+				},
+			},
+			wantErrMsg: "row 2: field 2 is empty (must be the name of a package)",
+		},
+		{
+			name: "",
+			args: args{
+				filePath: "",
+				parseAs:  "",
+				rows: []string{
+					"crates.io,addr2line,",
+					",,,",
+				},
+			},
+			wantErrMsg: "record on line 2: wrong number of fields",
 		},
 		{
 			name: "",
@@ -347,6 +399,41 @@ func TestFromCSVFile(t *testing.T) {
 						Name:      "sentry/sdk",
 						Version:   "2.0.4",
 						Ecosystem: lockfile.ComposerEcosystem,
+					},
+				},
+			},
+		},
+		{
+			name: "",
+			args: args{
+				pathToCSV: "fixtures/csv/commits.csv",
+				parseAs:   "-",
+			},
+			want: lockfile.Lockfile{
+				FilePath: "fixtures/csv/commits.csv",
+				ParsedAs: "-",
+				Packages: []lockfile.PackageDetails{
+					{
+						Name:      "@typescript-eslint/types",
+						Version:   "4.9.0",
+						Ecosystem: lockfile.PnpmEcosystem,
+					},
+					{
+						Name:      "addr2line",
+						Version:   "0.15.2",
+						Ecosystem: lockfile.CargoEcosystem,
+					},
+					{
+						Name:      "babel-preset-php",
+						Version:   "",
+						Ecosystem: "",
+						Commit:    "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
+					},
+					{
+						Name:      "vue",
+						Version:   "",
+						Ecosystem: "",
+						Commit:    "bb253db0b3e17124b6d1fe93fbf2db35470a1347",
 					},
 				},
 			},

--- a/pkg/lockfile/fixtures/csv/commits.csv
+++ b/pkg/lockfile/fixtures/csv/commits.csv
@@ -1,0 +1,4 @@
+npm,"@typescript-eslint/types",4.9.0
+,"vue",bb253db0b3e17124b6d1fe93fbf2db35470a1347
+crates.io,addr2line,0.15.2
+,"babel-preset-php",c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced

--- a/pkg/lockfile/parse.go
+++ b/pkg/lockfile/parse.go
@@ -51,6 +51,10 @@ func toSliceOfEcosystems(ecosystemsMap map[Ecosystem]struct{}) []Ecosystem {
 	ecosystems := make([]Ecosystem, 0, len(ecosystemsMap))
 
 	for ecosystem := range ecosystemsMap {
+		if ecosystem == "" {
+			continue
+		}
+
 		ecosystems = append(ecosystems, ecosystem)
 	}
 


### PR DESCRIPTION
I'm not the happiest about effectively making an empty ecosystem valid, but the alternative was to have a special ecosystem which had other annoying qualities.

I've set `ecosystem` to be omitted if it's empty when outputting as JSON, though I'd prefer `null` but I got a panic when I tried a custom marshaller and honestly it should be fine 🤷 

Resolves #110 