### PR TITLE
fix: represent empty ecosystems with `"<unknown>"`

### DIFF
--- a/pkg/lockfile/parse.go
+++ b/pkg/lockfile/parse.go
@@ -83,7 +83,13 @@ func (l Lockfile) ToString() string {
 	lines := make([]string, 0, len(l.Packages))
 
 	for _, details := range l.Packages {
-		ln := fmt.Sprintf("  %s: %s", details.Ecosystem, details.Name)
+		ecosystem := details.Ecosystem
+
+		if ecosystem == "" {
+			ecosystem = "<unknown>"
+		}
+
+		ln := fmt.Sprintf("  %s: %s", ecosystem, details.Name)
 
 		if details.Version != "" {
 			ln += "@" + details.Version

--- a/pkg/lockfile/parse_test.go
+++ b/pkg/lockfile/parse_test.go
@@ -144,6 +144,9 @@ func TestLockfile_ToString(t *testing.T) {
 		"  npm: @typescript-eslint/types@5.13.0",
 		"  crates.io: wasi@0.10.2+wasi-snapshot-preview1",
 		"  Packagist: sentry/sdk@2.0.4",
+		"  crates.io: no-version",
+		"  <unknown>: no-ecosystem@1.2.3",
+		"  <unknown>: no-ecosystem@1.2.3 (with-commit)",
 	}, "\n")
 
 	lockf := lockfile.Lockfile{
@@ -167,6 +170,22 @@ func TestLockfile_ToString(t *testing.T) {
 				Name:      "sentry/sdk",
 				Version:   "2.0.4",
 				Ecosystem: lockfile.ComposerEcosystem,
+			},
+			{
+				Name:      "no-version",
+				Version:   "",
+				Ecosystem: lockfile.CargoEcosystem,
+			},
+			{
+				Name:      "no-ecosystem",
+				Version:   "1.2.3",
+				Ecosystem: "",
+			},
+			{
+				Name:      "no-ecosystem",
+				Version:   "1.2.3",
+				Ecosystem: "",
+				Commit:    "with-commit",
 			},
 		},
 	}


### PR DESCRIPTION
This makes sense once #111 is landed. I've also included a few test cases that weren't previously being covered (getting us a total 0.5% more coverage!)