### PR TITLE
refactor: rename `ToString` functions to `String`, per go convention

### DIFF
--- a/internal/reporter/report.go
+++ b/internal/reporter/report.go
@@ -98,7 +98,7 @@ func (r Report) describeIgnores() string {
 	)
 }
 
-func (r Report) ToString() string {
+func (r Report) String() string {
 	count := r.countKnownVulnerabilities()
 	ignoreMsg := r.describeIgnores()
 	word := "known"

--- a/internal/reporter/report_test.go
+++ b/internal/reporter/report_test.go
@@ -234,19 +234,19 @@ func TestReport_HasIgnoredVulnerabilities(t *testing.T) {
 	}
 }
 
-func TestReport_ToString_NoVulnerabilities(t *testing.T) {
+func TestReport_String_NoVulnerabilities(t *testing.T) {
 	t.Parallel()
 
 	msg := "no known vulnerabilities found"
 
 	r := reporter.Report{}
 
-	if actual := r.ToString(); !strings.Contains(actual, msg) {
+	if actual := r.String(); !strings.Contains(actual, msg) {
 		t.Errorf("Expected \"%s\" to contain \"%s\" but it did not", actual, msg)
 	}
 }
 
-func TestReport_ToString_OneVulnerability(t *testing.T) {
+func TestReport_String_OneVulnerability(t *testing.T) {
 	t.Parallel()
 
 	expected := strings.Join([]string{
@@ -276,12 +276,12 @@ func TestReport_ToString_OneVulnerability(t *testing.T) {
 		},
 	}
 
-	if actual := r.ToString(); expected != actual {
+	if actual := r.String(); expected != actual {
 		t.Errorf("\nExpected:\n%s\nActual:\n%s", expected, actual)
 	}
 }
 
-func TestReport_ToString_MultipleVulnerabilities(t *testing.T) {
+func TestReport_String_MultipleVulnerabilities(t *testing.T) {
 	t.Parallel()
 
 	expected := strings.Join([]string{
@@ -334,12 +334,12 @@ func TestReport_ToString_MultipleVulnerabilities(t *testing.T) {
 		},
 	}
 
-	if actual := r.ToString(); expected != actual {
+	if actual := r.String(); expected != actual {
 		t.Errorf("\nExpected:\n%s\nActual:\n%s", expected, actual)
 	}
 }
 
-func TestReport_ToString_AllIgnoredVulnerabilities(t *testing.T) {
+func TestReport_String_AllIgnoredVulnerabilities(t *testing.T) {
 	t.Parallel()
 
 	msg := "no new vulnerabilities found (2 were ignored)"
@@ -376,12 +376,12 @@ func TestReport_ToString_AllIgnoredVulnerabilities(t *testing.T) {
 		},
 	}
 
-	if actual := r.ToString(); !strings.Contains(actual, msg) {
+	if actual := r.String(); !strings.Contains(actual, msg) {
 		t.Errorf("Expected \"%s\" to contain \"%s\" but it did not", actual, msg)
 	}
 }
 
-func TestReport_ToString_SomeIgnoredVulnerability(t *testing.T) {
+func TestReport_String_SomeIgnoredVulnerability(t *testing.T) {
 	t.Parallel()
 
 	expected := strings.Join([]string{
@@ -424,7 +424,7 @@ func TestReport_ToString_SomeIgnoredVulnerability(t *testing.T) {
 		},
 	}
 
-	if actual := r.ToString(); expected != actual {
+	if actual := r.String(); expected != actual {
 		t.Errorf("\nExpected:\n%s\nActual:\n%s", expected, actual)
 	}
 }

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -48,7 +48,7 @@ func (r *Reporter) PrintText(msg string) {
 }
 
 type Result interface {
-	ToString() string
+	String() string
 }
 
 func (r *Reporter) PrintResult(result Result) {
@@ -58,7 +58,7 @@ func (r *Reporter) PrintResult(result Result) {
 		return
 	}
 
-	fmt.Fprint(r.stdout, result.ToString())
+	fmt.Fprint(r.stdout, result.String())
 }
 
 // PrintJSONResults prints any results that this reporter has collected to

--- a/internal/reporter/reporter_test.go
+++ b/internal/reporter/reporter_test.go
@@ -11,12 +11,12 @@ import (
 )
 
 type TestResult struct {
-	String               string `json:"value"`
+	Value                string `json:"value"`
 	ErrorWhenMarshalling bool   `json:"-"`
 }
 
-func (r TestResult) ToString() string {
-	return r.String
+func (r TestResult) String() string {
+	return r.Value
 }
 
 func (r TestResult) MarshalJSON() ([]byte, error) {
@@ -62,7 +62,7 @@ func TestReporter_PrintResult(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	r := reporter.New(stdout, stderr, false)
 
-	r.PrintResult(TestResult{String: msg})
+	r.PrintResult(TestResult{Value: msg})
 
 	if gotStdout := stdout.String(); gotStdout != msg {
 		t.Errorf("Expected stdout to have \"%s\", but got \"%s\"", msg, gotStdout)
@@ -82,7 +82,7 @@ func TestReporter_PrintResult_OutputAsJSON(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	r := reporter.New(stdout, stderr, true)
 
-	r.PrintResult(TestResult{String: msg})
+	r.PrintResult(TestResult{Value: msg})
 
 	if gotStdout := stdout.String(); gotStdout != "" {
 		t.Errorf("Expected stdout to be empty, but got \"%s\"", gotStdout)
@@ -112,7 +112,7 @@ func TestReporter_PrintResult_OutputAsJSON_Error(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	r := reporter.New(stdout, stderr, true)
 
-	r.PrintResult(TestResult{String: msg, ErrorWhenMarshalling: true})
+	r.PrintResult(TestResult{Value: msg, ErrorWhenMarshalling: true})
 
 	if gotStdout := stdout.String(); gotStdout != "" {
 		t.Errorf("Expected stdout to be empty, but got \"%s\"", gotStdout)

--- a/pkg/lockfile/parse.go
+++ b/pkg/lockfile/parse.go
@@ -83,7 +83,7 @@ type Lockfile struct {
 	Packages Packages `json:"packages"`
 }
 
-func (l Lockfile) ToString() string {
+func (l Lockfile) String() string {
 	lines := make([]string, 0, len(l.Packages))
 
 	for _, details := range l.Packages {

--- a/pkg/lockfile/parse_test.go
+++ b/pkg/lockfile/parse_test.go
@@ -136,7 +136,7 @@ func TestListParsers(t *testing.T) {
 	}
 }
 
-func TestLockfile_ToString(t *testing.T) {
+func TestLockfile_String(t *testing.T) {
 	t.Parallel()
 
 	expected := strings.Join([]string{
@@ -190,7 +190,7 @@ func TestLockfile_ToString(t *testing.T) {
 		},
 	}
 
-	if actual := lockf.ToString(); expected != actual {
+	if actual := lockf.String(); expected != actual {
 		t.Errorf("\nExpected:\n%s\nActual:\n%s", expected, actual)
 	}
 }

--- a/pkg/semantic/compare_test.go
+++ b/pkg/semantic/compare_test.go
@@ -33,9 +33,9 @@ func expectCompareResult(
 	if actualResult := a.Compare(b); actualResult != expectedResult {
 		t.Errorf(
 			"Expected %s to be %s %s, but it was %s",
-			a.ToString(),
+			a.String(),
 			compareWord(t, expectedResult),
-			b.ToString(),
+			b.String(),
 			compareWord(t, actualResult),
 		)
 	}

--- a/pkg/semantic/parse_test.go
+++ b/pkg/semantic/parse_test.go
@@ -54,10 +54,10 @@ func expectParsedVersionToMatchOriginalString(t *testing.T, str string) semantic
 
 	actualVersion := semantic.Parse(str)
 
-	if actualVersion.ToString() != str {
+	if actualVersion.String() != str {
 		t.Errorf(
 			"Parsed version as a string did not equal original: %s != %s",
-			actualVersion.ToString(),
+			actualVersion.String(),
 			str,
 		)
 	}
@@ -85,10 +85,10 @@ func expectParsedVersionToMatchString(
 
 	actualVersion := semantic.Parse(str)
 
-	if actualVersion.ToString() != expectedString {
+	if actualVersion.String() != expectedString {
 		t.Errorf(
 			"Parsed version as a string did not equal expected: %s != %s",
-			actualVersion.ToString(),
+			actualVersion.String(),
 			expectedString,
 		)
 	}

--- a/pkg/semantic/version.go
+++ b/pkg/semantic/version.go
@@ -21,7 +21,7 @@ func (components *Components) Fetch(n int) int {
 	return (*components)[n]
 }
 
-func (v Version) ToString() string {
+func (v Version) String() string {
 	str := ""
 
 	if v.LeadingV {


### PR DESCRIPTION
At the time I didn't know that Go already has a `ToString` convention, which is `String`.

While renaming doesn't let us remove any code (or maybe it does, I've just not hunted around for it), this should increase operability for those using the packages.