### PR TITLE
fix: use updated at date from cache when in offline mode

### DIFF
--- a/pkg/database/zip.go
+++ b/pkg/database/zip.go
@@ -56,6 +56,8 @@ func (db *ZipDB) fetchZip() ([]byte, error) {
 			return nil, ErrOfflineDatabaseNotFound
 		}
 
+		db.UpdatedAt = cache.Date
+
 		return cache.Body, nil
 	}
 

--- a/pkg/database/zip_test.go
+++ b/pkg/database/zip_test.go
@@ -26,6 +26,32 @@ func cachePath(url string) string {
 	return filepath.Join(os.TempDir(), fileName)
 }
 
+func cacheWrite(t *testing.T, cache database.Cache) {
+	t.Helper()
+
+	cacheContents, err := json.Marshal(cache)
+
+	if err == nil {
+		// nolint:gosec // being world readable is fine
+		err = os.WriteFile(cachePath(cache.URL), cacheContents, 0644)
+	}
+
+	if err != nil {
+		t.Errorf("unexpected error with cache: %v", err)
+	}
+}
+
+func cacheWriteBad(t *testing.T, url string, contents string) {
+	t.Helper()
+
+	// nolint:gosec // being world readable is fine
+	err := os.WriteFile(cachePath(url), []byte(contents), 0644)
+
+	if err != nil {
+		t.Errorf("unexpected error with cache: %v", err)
+	}
+}
+
 func createZipServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, CleanUpZipServerFn) {
 	t.Helper()
 
@@ -67,7 +93,7 @@ func zipOSVs(t *testing.T, osvs map[string]database.OSV) []byte {
 	return buf.Bytes()
 }
 
-func TestNewZippedDB_OfflineWithoutCache(t *testing.T) {
+func TestNewZippedDB_Offline_WithoutCache(t *testing.T) {
 	t.Parallel()
 
 	ts, cleanup := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -79,6 +105,60 @@ func TestNewZippedDB_OfflineWithoutCache(t *testing.T) {
 
 	if !errors.Is(err, database.ErrOfflineDatabaseNotFound) {
 		t.Errorf("expected \"%v\" error but got \"%v\"", database.ErrOfflineDatabaseNotFound, err)
+	}
+}
+
+func TestNewZippedDB_Offline_WithCache(t *testing.T) {
+	t.Parallel()
+
+	date := "Fri, 17 Jun 2022 22:28:13 GMT"
+	osvs := []database.OSV{
+		{ID: "GHSA-1"},
+		{ID: "GHSA-2"},
+		{ID: "GHSA-3"},
+		{ID: "GHSA-4"},
+		{ID: "GHSA-5"},
+	}
+
+	ts, cleanup := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("a server request was made when running offline")
+	})
+	defer cleanup()
+
+	cacheWrite(t, database.Cache{
+		URL:  ts.URL,
+		ETag: "",
+		Date: date,
+		Body: zipOSVs(t, map[string]database.OSV{
+			"GHSA-1.json": {ID: "GHSA-1"},
+			"GHSA-2.json": {ID: "GHSA-2"},
+			"GHSA-3.json": {ID: "GHSA-3"},
+			"GHSA-4.json": {ID: "GHSA-4"},
+			"GHSA-5.json": {ID: "GHSA-5"},
+		}),
+	})
+
+	db, err := database.NewZippedDB(ts.URL, true)
+
+	if err != nil {
+		t.Errorf("unexpected error \"%v\"", err)
+	}
+
+	if db.UpdatedAt != date {
+		t.Errorf("db.UpdatedAt got = \"%s\", want = \"%s\"", db.UpdatedAt, date)
+	}
+
+	vulns := db.Vulnerabilities(true)
+
+	sort.Slice(vulns, func(i, j int) bool {
+		return vulns[i].ID < vulns[j].ID
+	})
+	sort.Slice(osvs, func(i, j int) bool {
+		return osvs[i].ID < osvs[j].ID
+	})
+
+	if !reflect.DeepEqual(vulns, osvs) {
+		t.Errorf("db is missing some vulnerabilities: %v vs %v", vulns, osvs)
 	}
 }
 
@@ -107,7 +187,7 @@ func TestNewZippedDB_UnsupportedProtocol(t *testing.T) {
 	}
 }
 
-func TestNewZippedDB_Online_Successful(t *testing.T) {
+func TestNewZippedDB_Online_WithoutCache(t *testing.T) {
 	t.Parallel()
 
 	osvs := []database.OSV{
@@ -135,7 +215,164 @@ func TestNewZippedDB_Online_Successful(t *testing.T) {
 		t.Errorf("unexpected error \"%v\"", err)
 	}
 
-	vulns := db.Vulnerabilities(false)
+	vulns := db.Vulnerabilities(true)
+
+	sort.Slice(vulns, func(i, j int) bool {
+		return vulns[i].ID < vulns[j].ID
+	})
+	sort.Slice(osvs, func(i, j int) bool {
+		return osvs[i].ID < osvs[j].ID
+	})
+
+	if !reflect.DeepEqual(vulns, osvs) {
+		t.Errorf("db is missing some vulnerabilities: %v vs %v", vulns, osvs)
+	}
+}
+
+func TestNewZippedDB_Online_WithCache(t *testing.T) {
+	t.Parallel()
+
+	date := "Fri, 18 Jun 2022 22:28:13 GMT"
+	osvs := []database.OSV{
+		{ID: "GHSA-1"},
+		{ID: "GHSA-2"},
+		{ID: "GHSA-3"},
+	}
+
+	ts, cleanup := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if dateHeader := r.Header.Get("If-Modified-Since"); dateHeader != date {
+			t.Errorf("incorrect Date header: got = \"%s\", want = \"%s\"", dateHeader, date)
+		}
+
+		w.WriteHeader(http.StatusNotModified)
+	})
+	defer cleanup()
+
+	cacheWrite(t, database.Cache{
+		URL:  ts.URL,
+		ETag: "",
+		Date: date,
+		Body: zipOSVs(t, map[string]database.OSV{
+			"GHSA-1.json": {ID: "GHSA-1"},
+			"GHSA-2.json": {ID: "GHSA-2"},
+			"GHSA-3.json": {ID: "GHSA-3"},
+		}),
+	})
+
+	db, err := database.NewZippedDB(ts.URL, false)
+
+	if err != nil {
+		t.Fatalf("unexpected error \"%v\"", err)
+	}
+
+	if db.UpdatedAt != date {
+		t.Errorf("db.UpdatedAt got = \"%s\", want = \"%s\"", db.UpdatedAt, date)
+	}
+
+	vulns := db.Vulnerabilities(true)
+
+	sort.Slice(vulns, func(i, j int) bool {
+		return vulns[i].ID < vulns[j].ID
+	})
+	sort.Slice(osvs, func(i, j int) bool {
+		return osvs[i].ID < osvs[j].ID
+	})
+
+	if !reflect.DeepEqual(vulns, osvs) {
+		t.Errorf("db is missing some vulnerabilities: %v vs %v", vulns, osvs)
+	}
+}
+
+func TestNewZippedDB_Online_WithOldCache(t *testing.T) {
+	t.Parallel()
+
+	date := "Fri, 17 Jun 2022 22:28:13 GMT"
+	osvs := []database.OSV{
+		{ID: "GHSA-1"},
+		{ID: "GHSA-2"},
+		{ID: "GHSA-3"},
+		{ID: "GHSA-4"},
+		{ID: "GHSA-5"},
+	}
+
+	ts, cleanup := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if dateHeader := r.Header.Get("If-Modified-Since"); dateHeader != date {
+			t.Errorf("incorrect Date header: got = \"%s\", want = \"%s\"", dateHeader, date)
+		}
+
+		w.Header().Set("Date", "Today")
+		_, _ = w.Write(zipOSVs(t, map[string]database.OSV{
+			"GHSA-1.json": {ID: "GHSA-1"},
+			"GHSA-2.json": {ID: "GHSA-2"},
+			"GHSA-3.json": {ID: "GHSA-3"},
+			"GHSA-4.json": {ID: "GHSA-4"},
+			"GHSA-5.json": {ID: "GHSA-5"},
+		}))
+	})
+	defer cleanup()
+
+	cacheWrite(t, database.Cache{
+		URL:  ts.URL,
+		ETag: "",
+		Date: date,
+		Body: zipOSVs(t, map[string]database.OSV{
+			"GHSA-1.json": {ID: "GHSA-1"},
+			"GHSA-2.json": {ID: "GHSA-2"},
+			"GHSA-3.json": {ID: "GHSA-3"},
+		}),
+	})
+
+	db, err := database.NewZippedDB(ts.URL, false)
+
+	if err != nil {
+		t.Fatalf("unexpected error \"%v\"", err)
+	}
+
+	if db.UpdatedAt != "Today" {
+		t.Errorf("db.UpdatedAt got = \"%s\", want = \"%s\"", db.UpdatedAt, "Today")
+	}
+
+	vulns := db.Vulnerabilities(true)
+
+	sort.Slice(vulns, func(i, j int) bool {
+		return vulns[i].ID < vulns[j].ID
+	})
+	sort.Slice(osvs, func(i, j int) bool {
+		return osvs[i].ID < osvs[j].ID
+	})
+
+	if !reflect.DeepEqual(vulns, osvs) {
+		t.Errorf("db is missing some vulnerabilities: %v vs %v", vulns, osvs)
+	}
+}
+
+func TestNewZippedDB_Online_WithBadCache(t *testing.T) {
+	t.Parallel()
+
+	osvs := []database.OSV{
+		{ID: "GHSA-1"},
+		{ID: "GHSA-2"},
+		{ID: "GHSA-3"},
+	}
+
+	ts, cleanup := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(zipOSVs(t, map[string]database.OSV{
+			"GHSA-1.json": {ID: "GHSA-1"},
+			"GHSA-2.json": {ID: "GHSA-2"},
+			"GHSA-3.json": {ID: "GHSA-3"},
+		}))
+	})
+	defer cleanup()
+
+	cacheWriteBad(t, ts.URL, "this is not json!")
+
+	db, err := database.NewZippedDB(ts.URL, false)
+
+	if err != nil {
+		t.Fatalf("unexpected error \"%v\"", err)
+	}
+
+	vulns := db.Vulnerabilities(true)
 
 	sort.Slice(vulns, func(i, j int) bool {
 		return vulns[i].ID < vulns[j].ID


### PR DESCRIPTION
Currently when running in offline mode the detector outputs "last updated )":

```
❯ osv-detector-t --offline --parse-as csv-row ''
Loaded the following OSV databases:
  GHADB (reviewed) (0 vulnerabilities, including withdrawn - last updated )

-: found 0 packages
  Using config at ./.osv-detector.yaml (1 ignore)
  Using db GHADB (reviewed) (0 vulnerabilities, including withdrawn - last updated )

  no known vulnerabilities found
```

This fixes that by setting `UpdatedAt` to be based off the caches date when in offline mode. I've also chunked in some more cache-focused tests (including one that catches this bug), which increases our coverage by a couple of percents.