### PR TITLE
fix: don't load databases or config when only listing packages

### DIFF
--- a/main.go
+++ b/main.go
@@ -325,12 +325,20 @@ func collectEcosystems(files []lockfileAndConfigOrErr) []internal.Ecosystem {
 func loadDatabases(
 	r *reporter.Reporter,
 	ecosystems []internal.Ecosystem,
+	listPackages bool,
 	useDatabases bool,
 	useAPI bool,
 	batchSize int,
 	offline bool,
 ) (OSVDatabases, bool) {
 	var dbs OSVDatabases
+
+	// an easy dirty little optimisation: we don't need any databases
+	// if we're going to be listing packages, so return the empty slice
+	if listPackages {
+		return dbs, false
+	}
+
 	errored := false
 
 	if useDatabases {
@@ -440,7 +448,10 @@ This flag can be passed multiple times to ignore different vulnerabilities`)
 	var config configer.Config
 	loadLocalConfig := !*noConfig
 
-	if loadLocalConfig && *configPath != "" {
+	// if we're listing packages, then we don't need to do _any_ config loading
+	if *listPackages {
+		loadLocalConfig = false
+	} else if loadLocalConfig && *configPath != "" {
 		con, err := configer.Load(*configPath)
 
 		if err != nil {
@@ -460,6 +471,7 @@ This flag can be passed multiple times to ignore different vulnerabilities`)
 	dbs, errored := loadDatabases(
 		r,
 		ecosystems,
+		*listPackages,
 		*useDatabases,
 		*useAPI,
 		*batchSize,

--- a/main_test.go
+++ b/main_test.go
@@ -165,9 +165,6 @@ func TestRun_ListPackages(t *testing.T) {
 			args:         []string{"--list-packages", "./fixtures/locks-one"},
 			wantExitCode: 0,
 			wantStdout: `
-				Loading OSV databases for the following ecosystems:
-					npm (%% vulnerabilities, including withdrawn - last updated %%)
-
 				fixtures/locks-one/yarn.lock: found 1 package
 					npm: balanced-match@1.0.2
 			`,
@@ -178,11 +175,6 @@ func TestRun_ListPackages(t *testing.T) {
 			args:         []string{"--list-packages", "./fixtures/locks-many"},
 			wantExitCode: 0,
 			wantStdout: `
-				Loading OSV databases for the following ecosystems:
-					RubyGems (%% vulnerabilities, including withdrawn - last updated %%)
-					Packagist (%% vulnerabilities, including withdrawn - last updated %%)
-					npm (%% vulnerabilities, including withdrawn - last updated %%)
-
 				fixtures/locks-many/Gemfile.lock: found 1 package
 					RubyGems: ast@2.4.2
 				fixtures/locks-many/composer.lock: found 1 package
@@ -197,8 +189,6 @@ func TestRun_ListPackages(t *testing.T) {
 			args:         []string{"--list-packages", "./fixtures/locks-empty"},
 			wantExitCode: 0,
 			wantStdout: `
-				Loading OSV databases for the following ecosystems:
-
 				fixtures/locks-empty/Gemfile.lock: found 0 packages
 
 				fixtures/locks-empty/composer.lock: found 0 packages
@@ -216,9 +206,6 @@ func TestRun_ListPackages(t *testing.T) {
 				{"results":[{"filePath":"fixtures/locks-one/yarn.lock","parsedAs":"yarn.lock","packages":[{"name":"balanced-match","version":"1.0.2","ecosystem":"npm"}]}]}
 			`,
 			wantStderr: `
-				Loading OSV databases for the following ecosystems:
-          npm (%% vulnerabilities, including withdrawn - last updated %%)
-
 				fixtures/locks-one/yarn.lock: found 1 package
 			`,
 		},


### PR DESCRIPTION
If we've been asked to just list the packages in the lockfiles being parsed then we can skip both loading any databases (which adds significant overhead vs the task we're doing) _and_ loading any configs (which are expected to never have anything that would be relevant to `--list-packages`).

The most important aspect of this fix is that it means `--list-packages` is completely offline always, which should make it more reasonable to use for other tools.