### PR TITLE
ci: update version of Go used for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  GO_VERSION: '1.17.2'
+  GO_VERSION: '1.17.9'
 
 jobs:
   test-ubuntu:


### PR DESCRIPTION
I realised while doing #122 I forgot to update the version of Go being used in the release workflow 😬 