### PR TITLE
ci: don't use `actions/setup-go` cache for golangci-lint as it has its own cache

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -52,7 +52,6 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,6 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
Currently we get a bunch of "errors":

<img width="860" alt="image" src="https://user-images.githubusercontent.com/3151613/175667977-84501656-29f7-4bef-bc8a-fa935fcaf4db.png">

Turns out this action already does the caching, and these errors come out as annotations which means any issues won't be nicely highlighted since there's a very low limit on how many annotations each job can output.