### PR TITLE
test: adjust yarn lock parser case names to match parser function name

### DIFF
--- a/pkg/lockfile/parse-yarn-lock-v1_test.go
+++ b/pkg/lockfile/parse-yarn-lock-v1_test.go
@@ -14,7 +14,7 @@ func TestParseYarnLock_v1_FileDoesNotExist(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
-func TestYarnLock_v1_NoPackages(t *testing.T) {
+func TestParseYarnLock_v1_NoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/empty.v1.lock")
@@ -26,7 +26,7 @@ func TestYarnLock_v1_NoPackages(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
-func TestYarnLock_v1_OnePackage(t *testing.T) {
+func TestParseYarnLock_v1_OnePackage(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/one-package.v1.lock")
@@ -44,7 +44,7 @@ func TestYarnLock_v1_OnePackage(t *testing.T) {
 	})
 }
 
-func TestYarnLock_v1_TwoPackages(t *testing.T) {
+func TestParseYarnLock_v1_TwoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/two-packages.v1.lock")
@@ -67,7 +67,7 @@ func TestYarnLock_v1_TwoPackages(t *testing.T) {
 	})
 }
 
-func TestYarnLock_v1_MultipleVersions(t *testing.T) {
+func TestParseYarnLock_v1_MultipleVersions(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/multiple-versions.v1.lock")
@@ -100,7 +100,7 @@ func TestYarnLock_v1_MultipleVersions(t *testing.T) {
 	})
 }
 
-func TestYarnLock_v1_MultipleConstraints(t *testing.T) {
+func TestParseYarnLock_v1_MultipleConstraints(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/multiple-constraints.v1.lock")
@@ -123,7 +123,7 @@ func TestYarnLock_v1_MultipleConstraints(t *testing.T) {
 	})
 }
 
-func TestYarnLock_v1_ScopedPackages(t *testing.T) {
+func TestParseYarnLock_v1_ScopedPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/scoped-packages.v1.lock")
@@ -146,7 +146,7 @@ func TestYarnLock_v1_ScopedPackages(t *testing.T) {
 	})
 }
 
-func TestYarnLock_v1_VersionsWithBuildString(t *testing.T) {
+func TestParseYarnLock_v1_VersionsWithBuildString(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/versions-with-build-strings.v1.lock")
@@ -184,7 +184,7 @@ func TestYarnLock_v1_VersionsWithBuildString(t *testing.T) {
 	})
 }
 
-func TestYarnLock_v1_Commits(t *testing.T) {
+func TestParseYarnLock_v1_Commits(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/commits.v1.lock")
@@ -305,7 +305,7 @@ func TestYarnLock_v1_Commits(t *testing.T) {
 	})
 }
 
-func TestYarnLock_v1_Files(t *testing.T) {
+func TestParseYarnLock_v1_Files(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/files.v1.lock")

--- a/pkg/lockfile/parse-yarn-lock-v2_test.go
+++ b/pkg/lockfile/parse-yarn-lock-v2_test.go
@@ -14,7 +14,7 @@ func TestParseYarnLock_v2_FileDoesNotExist(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
-func TestYarnLock_v2_NoPackages(t *testing.T) {
+func TestParseYarnLock_v2_NoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/empty.v2.lock")
@@ -26,7 +26,7 @@ func TestYarnLock_v2_NoPackages(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
-func TestYarnLock_v2_OnePackage(t *testing.T) {
+func TestParseYarnLock_v2_OnePackage(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/one-package.v2.lock")
@@ -44,7 +44,7 @@ func TestYarnLock_v2_OnePackage(t *testing.T) {
 	})
 }
 
-func TestYarnLock_v2_TwoPackages(t *testing.T) {
+func TestParseYarnLock_v2_TwoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/two-packages.v2.lock")
@@ -67,7 +67,7 @@ func TestYarnLock_v2_TwoPackages(t *testing.T) {
 	})
 }
 
-func TestYarnLock_v2_MultipleVersions(t *testing.T) {
+func TestParseYarnLock_v2_MultipleVersions(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/multiple-versions.v2.lock")
@@ -95,7 +95,7 @@ func TestYarnLock_v2_MultipleVersions(t *testing.T) {
 	})
 }
 
-func TestYarnLock_v2_ScopedPackages(t *testing.T) {
+func TestParseYarnLock_v2_ScopedPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/scoped-packages.v2.lock")
@@ -123,7 +123,7 @@ func TestYarnLock_v2_ScopedPackages(t *testing.T) {
 	})
 }
 
-func TestYarnLock_v2_VersionsWithBuildString(t *testing.T) {
+func TestParseYarnLock_v2_VersionsWithBuildString(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/versions-with-build-strings.v2.lock")
@@ -151,7 +151,7 @@ func TestYarnLock_v2_VersionsWithBuildString(t *testing.T) {
 	})
 }
 
-func TestYarnLock_v2_Commits(t *testing.T) {
+func TestParseYarnLock_v2_Commits(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/commits.v2.lock")
@@ -206,7 +206,7 @@ func TestYarnLock_v2_Commits(t *testing.T) {
 	})
 }
 
-func TestYarnLock_v2_Files(t *testing.T) {
+func TestParseYarnLock_v2_Files(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/files.v2.lock")


### PR DESCRIPTION
A mistake from the early days 😅 