### PR TITLE
test: add more coverage of cli core

### DIFF
--- a/fixtures/csvs-files/not-a-csv.xml
+++ b/fixtures/csvs-files/not-a-csv.xml
@@ -1,0 +1,18 @@
+<project>
+  <properties>
+    <mavenVersion>3.0</mavenVersion>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <version>4.1.42.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.25</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/fixtures/csvs-files/two-rows.csv
+++ b/fixtures/csvs-files/two-rows.csv
@@ -1,0 +1,2 @@
+NuGet,Yarp.ReverseProxy,
+npm,@typescript-eslint/types,5.13.0

--- a/main_test.go
+++ b/main_test.go
@@ -137,6 +137,16 @@ func TestRun(t *testing.T) {
 				You must provide at least one path to either a lockfile or a directory containing a lockfile (see --help for usage and flags)
 			`,
 		},
+		// only the files in the given directories are checked (no recursion)
+		{
+			name:         "",
+			args:         []string{"./fixtures/"},
+			wantExitCode: 127,
+			wantStdout:   "",
+			wantStderr: `
+				You must provide at least one path to either a lockfile or a directory containing a lockfile (see --help for usage and flags)
+			`,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/main_test.go
+++ b/main_test.go
@@ -349,6 +349,62 @@ func TestRun_Lockfile(t *testing.T) {
 	}
 }
 
+func TestRun_DBs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		args         []string
+		wantExitCode int
+		wantStdout   string
+		wantStderr   string
+	}{
+		{
+			name:         "",
+			args:         []string{"--use-dbs=false", "./fixtures/locks-one"},
+			wantExitCode: 0,
+			wantStdout: `
+				fixtures/locks-one/yarn.lock: found 1 package
+					no known vulnerabilities found
+			`,
+			wantStderr: "",
+		},
+		{
+			name:         "",
+			args:         []string{"--use-api", "./fixtures/locks-one"},
+			wantExitCode: 0,
+			wantStdout: `
+				Loading OSV databases for the following ecosystems:
+					npm (%% vulnerabilities, including withdrawn - last updated %%)
+
+				fixtures/locks-one/yarn.lock: found 1 package
+					no known vulnerabilities found
+			`,
+			wantStderr: "",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ec, stdout, stderr := runCLI(t, tt.args)
+
+			if ec != tt.wantExitCode {
+				t.Errorf("cli exited with code %d, not %d", ec, tt.wantExitCode)
+			}
+
+			if !areEqual(t, dedent(t, stdout), dedent(t, tt.wantStdout)) {
+				t.Errorf("stdout\n got: \n%s\n\n want:\n%s", dedent(t, stdout), dedent(t, tt.wantStdout))
+			}
+
+			if !areEqual(t, dedent(t, stderr), dedent(t, tt.wantStderr)) {
+				t.Errorf("stderr\n got:\n%s\n\n want:\n%s", dedent(t, stderr), dedent(t, tt.wantStderr))
+			}
+		})
+	}
+}
+
 func TestRun_ParseAs(t *testing.T) {
 	t.Parallel()
 

--- a/main_test.go
+++ b/main_test.go
@@ -127,6 +127,16 @@ func TestRun(t *testing.T) {
 				You must provide at least one path to either a lockfile or a directory containing a lockfile (see --help for usage and flags)
 			`,
 		},
+		{
+			name:         "",
+			args:         []string{"./fixtures/does/not/exist"},
+			wantExitCode: 127,
+			wantStdout:   "",
+			wantStderr: `
+				Error reading ./fixtures/does/not/exist: open ./fixtures/does/not/exist: no such file or directory
+				You must provide at least one path to either a lockfile or a directory containing a lockfile (see --help for usage and flags)
+			`,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
Originally I was doing some easy pickings (including some that result in more coverage in #114 vs right now), and now I've found a few bugs in the `csv-row` parser 🤦 (I'll address them in follow up PRs)