### PR TITLE
fix: require at least three fields to be present in csv row

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -596,6 +596,21 @@ func TestRun_ParseAs_CsvRow(t *testing.T) {
 			`,
 			wantStderr: "",
 		},
+		{
+			name: "",
+			args: []string{
+				"--no-config",
+				"--parse-as", "csv-row",
+				"NuGet,",
+				"npm,@typescript-eslint/types,5.13.0",
+			},
+			wantExitCode: 127,
+			wantStdout: `
+				Loading OSV databases for the following ecosystems:
+
+			`,
+			wantStderr: "Error, row 1: not enough fields (expected at least three)",
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -654,7 +669,7 @@ func TestRun_ParseAs_CsvFile(t *testing.T) {
 				Loading OSV databases for the following ecosystems:
 
 			`,
-			wantStderr: "Error, fixtures/csvs-files/not-a-csv.xml: row 1: not enough fields (missing at least ecosystem and package name)",
+			wantStderr: "Error, fixtures/csvs-files/not-a-csv.xml: row 1: not enough fields (expected at least three)",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/lockfile/csv.go
+++ b/pkg/lockfile/csv.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 )
 
-var errCSVRecordNotEnoughFields = errors.New("not enough fields (missing at least ecosystem and package name)")
+var errCSVRecordNotEnoughFields = errors.New("not enough fields (expected at least three)")
 var errCSVRecordMissingPackageField = errors.New("field 2 is empty (must be the name of a package)")
 var errCSVRecordMissingCommitField = errors.New("field 3 is empty (must be a commit)")
 
 func fromCSVRecord(lines []string) (PackageDetails, error) {
-	if len(lines) < 2 {
+	if len(lines) < 3 {
 		return PackageDetails{}, errCSVRecordNotEnoughFields
 	}
 

--- a/pkg/lockfile/csv_test.go
+++ b/pkg/lockfile/csv_test.go
@@ -217,6 +217,18 @@ func TestFromCSVRows_Errors(t *testing.T) {
 			},
 			wantErrMsg: "record on line 2: wrong number of fields",
 		},
+		{
+			name: "",
+			args: args{
+				filePath: "",
+				parseAs:  "",
+				rows: []string{
+					"NuGet,",
+					"npm,@typescript-eslint/types,5.13.0",
+				},
+			},
+			wantErrMsg: "row 1: not enough fields (expected at least three)",
+		},
 	}
 
 	for _, tt := range tests {
@@ -484,7 +496,7 @@ func TestFromCSVFile_Errors(t *testing.T) {
 				pathToCSV: "fixtures/csv/not-a-csv.xml",
 				parseAs:   "csv-file",
 			},
-			wantErrMsg: "fixtures/csv/not-a-csv.xml: row 1: not enough fields (missing at least ecosystem and package name)",
+			wantErrMsg: "fixtures/csv/not-a-csv.xml: row 1: not enough fields (expected at least three)",
 		},
 	}
 


### PR DESCRIPTION
Currently we panic if you don't provide the third field (version/commit), even though we do support it being blank - for now I've gone with just always requiring three fields since it just means adding a trailing comma.