### PR TITLE
fix: adjust error message to indicate directories must have "at least one" lockfile

### DIFF
--- a/main.go
+++ b/main.go
@@ -565,7 +565,7 @@ This flag can be passed multiple times to ignore different vulnerabilities`)
 
 	if len(pathsToLocks) == 0 {
 		r.PrintError(
-			"You must provide at least one path to either a lockfile or a directory containing a lockfile (see --help for usage and flags)\n",
+			"You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)\n",
 		)
 
 		return 127

--- a/main_test.go
+++ b/main_test.go
@@ -105,7 +105,7 @@ func TestRun(t *testing.T) {
 			wantExitCode: 127,
 			wantStdout:   "",
 			wantStderr: `
-				You must provide at least one path to either a lockfile or a directory containing a lockfile (see --help for usage and flags)
+				You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)
 			`,
 		},
 		{
@@ -141,7 +141,7 @@ func TestRun(t *testing.T) {
 			wantExitCode: 127,
 			wantStdout:   "",
 			wantStderr: `
-				You must provide at least one path to either a lockfile or a directory containing a lockfile (see --help for usage and flags)
+				You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)
 			`,
 		},
 		{
@@ -152,7 +152,7 @@ func TestRun(t *testing.T) {
 			// "file not found" message is different on Windows vs other OSs
 			wantStderr: `
 				Error reading ./fixtures/does/not/exist: open ./fixtures/does/not/exist: %%
-				You must provide at least one path to either a lockfile or a directory containing a lockfile (see --help for usage and flags)
+				You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)
 			`,
 		},
 		// only the files in the given directories are checked (no recursion)
@@ -162,7 +162,7 @@ func TestRun(t *testing.T) {
 			wantExitCode: 127,
 			wantStdout:   "",
 			wantStderr: `
-				You must provide at least one path to either a lockfile or a directory containing a lockfile (see --help for usage and flags)
+				You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)
 			`,
 		},
 	}


### PR DESCRIPTION
Very minor but I realised while building some tooling to use `osv-detector` that our error message for this situation could be better...