### PR TITLE
feat: use a unique exit code to indicate that no lockfiles could be found in the given args

### DIFF
--- a/main.go
+++ b/main.go
@@ -536,7 +536,9 @@ This flag can be passed multiple times to ignore different vulnerabilities`)
 			"You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)\n",
 		)
 
-		return 127
+		// use a specific exit code so that people can identify when the detector
+		// has "errored" because it can't find lockfiles to check
+		return 128
 	}
 
 	exitCode := 0

--- a/main_test.go
+++ b/main_test.go
@@ -136,7 +136,42 @@ func TestRun(t *testing.T) {
 					csv-row
 			`,
 		},
-		// when there are no lockfiles in a directory, the exit code should be different
+		// only the files in the given directories are checked (no recursion)
+		{
+			name:         "",
+			args:         []string{"./fixtures/"},
+			wantExitCode: 128,
+			wantStdout:   "",
+			wantStderr: `
+				You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)
+			`,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			testCli(t, tt)
+		})
+	}
+}
+
+func TestRun_EmptyDirExitCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []cliTestCase{
+		// no paths should return standard error exit code
+		{
+			name:         "",
+			args:         []string{},
+			wantExitCode: 127,
+			wantStdout:   "",
+			wantStderr: `
+				You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)
+			`,
+		},
+		// one directory without any lockfiles should result in "no lockfiles in directories" exit code
 		{
 			name:         "",
 			args:         []string{"./fixtures/locks-none"},
@@ -146,6 +181,17 @@ func TestRun(t *testing.T) {
 				You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)
 			`,
 		},
+		// two directories without any lockfiles should return "no lockfiles in directories" exit code
+		{
+			name:         "",
+			args:         []string{"./fixtures/locks-none", "./fixtures/"},
+			wantExitCode: 128,
+			wantStdout:   "",
+			wantStderr: `
+				You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)
+			`,
+		},
+		// a path to an unknown lockfile should return standard error exit code
 		{
 			name:         "",
 			args:         []string{"./fixtures/locks-none/my-file.txt"},
@@ -158,17 +204,20 @@ func TestRun(t *testing.T) {
 				Error, could not determine parser for fixtures/locks-none/my-file.txt
 			`,
 		},
-		// when there are no parsable lockfiles in the directory + --json should give sensible json
+		// mix and match of directory without any lockfiles and a path to an unknown lockfile should return standard exit code
 		{
 			name:         "",
-			args:         []string{"--json", "./fixtures/"},
-			wantExitCode: 128,
-			wantStdout:   `{"results":[]}`,
+			args:         []string{"./fixtures/locks-none/my-file.txt", "./fixtures/"},
+			wantExitCode: 127,
+			wantStdout: `
+				Loaded the following OSV databases:
+
+			`,
 			wantStderr: `
-				You must provide at least one path to either a lockfile or a directory containing a lockfile (see --help for usage and flags)
+				Error, could not determine parser for fixtures/locks-none/my-file.txt
 			`,
 		},
-		// when the directory does not exist, the exit code should not be for "no lockfiles found"
+		// when the directory does not exist, the exit code should not be for "no lockfiles in directories"
 		{
 			name:         "",
 			args:         []string{"./fixtures/does/not/exist"},
@@ -180,12 +229,24 @@ func TestRun(t *testing.T) {
 				You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)
 			`,
 		},
-		// only the files in the given directories are checked (no recursion)
+		// an empty directory + a directory that does not exist should return standard exit code
 		{
 			name:         "",
-			args:         []string{"./fixtures/"},
-			wantExitCode: 128,
+			args:         []string{"./fixtures/does/not/exist", "./fixtures/locks-none"},
+			wantExitCode: 127,
 			wantStdout:   "",
+			// "file not found" message is different on Windows vs other OSs
+			wantStderr: `
+				Error reading ./fixtures/does/not/exist: open ./fixtures/does/not/exist: %%
+				You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)
+			`,
+		},
+		// when there are no parsable lockfiles in the directory + --json should give sensible json
+		{
+			name:         "",
+			args:         []string{"--json", "./fixtures/locks-none"},
+			wantExitCode: 128,
+			wantStdout:   `{"results":[]}`,
 			wantStderr: `
 				You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)
 			`,

--- a/main_test.go
+++ b/main_test.go
@@ -102,7 +102,7 @@ func TestRun(t *testing.T) {
 		{
 			name:         "",
 			args:         []string{},
-			wantExitCode: 127,
+			wantExitCode: 128,
 			wantStdout:   "",
 			wantStderr: `
 				You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)
@@ -139,7 +139,7 @@ func TestRun(t *testing.T) {
 		{
 			name:         "",
 			args:         []string{"./fixtures/locks-none"},
-			wantExitCode: 127,
+			wantExitCode: 128,
 			wantStdout:   "",
 			wantStderr: `
 				You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)
@@ -148,7 +148,7 @@ func TestRun(t *testing.T) {
 		{
 			name:         "",
 			args:         []string{"./fixtures/does/not/exist"},
-			wantExitCode: 127,
+			wantExitCode: 128,
 			wantStdout:   "",
 			// "file not found" message is different on Windows vs other OSs
 			wantStderr: `
@@ -160,7 +160,7 @@ func TestRun(t *testing.T) {
 		{
 			name:         "",
 			args:         []string{"./fixtures/"},
-			wantExitCode: 127,
+			wantExitCode: 128,
 			wantStdout:   "",
 			wantStderr: `
 				You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)

--- a/main_test.go
+++ b/main_test.go
@@ -102,7 +102,7 @@ func TestRun(t *testing.T) {
 		{
 			name:         "",
 			args:         []string{},
-			wantExitCode: 128,
+			wantExitCode: 127,
 			wantStdout:   "",
 			wantStderr: `
 				You must provide at least one path to either a lockfile or a directory containing at least one lockfile (see --help for usage and flags)
@@ -136,6 +136,7 @@ func TestRun(t *testing.T) {
 					csv-row
 			`,
 		},
+		// when there are no lockfiles in a directory, the exit code should be different
 		{
 			name:         "",
 			args:         []string{"./fixtures/locks-none"},
@@ -147,8 +148,31 @@ func TestRun(t *testing.T) {
 		},
 		{
 			name:         "",
-			args:         []string{"./fixtures/does/not/exist"},
+			args:         []string{"./fixtures/locks-none/my-file.txt"},
+			wantExitCode: 127,
+			wantStdout: `
+				Loaded the following OSV databases:
+
+			`,
+			wantStderr: `
+				Error, could not determine parser for fixtures/locks-none/my-file.txt
+			`,
+		},
+		// when there are no parsable lockfiles in the directory + --json should give sensible json
+		{
+			name:         "",
+			args:         []string{"--json", "./fixtures/"},
 			wantExitCode: 128,
+			wantStdout:   `{"results":[]}`,
+			wantStderr: `
+				You must provide at least one path to either a lockfile or a directory containing a lockfile (see --help for usage and flags)
+			`,
+		},
+		// when the directory does not exist, the exit code should not be for "no lockfiles found"
+		{
+			name:         "",
+			args:         []string{"./fixtures/does/not/exist"},
+			wantExitCode: 127,
 			wantStdout:   "",
 			// "file not found" message is different on Windows vs other OSs
 			wantStderr: `


### PR DESCRIPTION
This makes it easier for tools to know when the detector didn't find anything to parse vs anything else - this is an important situation because this way tools can just point the detector at a directory without knowing if there will be anything for the detector to be able to parse.