### PR TITLE
feat: support skipping specific parts of configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,9 @@ lockfiles being checked with the `--config` flag:
 osv-detector --config ruby-ignores.yml path/to/my/first-ruby-project path/to/my/second-ruby-project
 ```
 
-Finally, you can disable loading any configs with the `--no-config` flag.
+You can have the detector ignore specific parts of the config with the
+`--no-config-ignores` and `--no-config-databases` flags, or ignore any configs
+all together with the `--no-config` flag.
 
 #### Ignoring certain vulnerabilities
 
@@ -231,6 +233,14 @@ The `url` should be either:
 For the file based database sources (`dir` and `zip`), the detector will
 recursively load all `.json` files from the `working-directory` relative to the
 root of the database as OSVs.
+
+> The detector assumes that you trust the source of the configuration file and
+> thus the databases that it points to.
+>
+> If you are using the detector in a way that allows users to provide arbitrary
+> config files that you don't trust, you can use the `--no-config-databases`
+> flag to have the detector load the rest of the config without any extra
+> databases it may define
 
 This is a very powerful feature as it enables you to create custom OSVs that can
 be easily consumed by multiple projects and that cover anything you want - for

--- a/main.go
+++ b/main.go
@@ -354,20 +354,6 @@ func (s *stringsFlag) Set(value string) error {
 	return nil
 }
 
-func allIgnores(global, local []string) []string {
-	ignores := make(
-		[]string,
-		0,
-		// len cannot return negative numbers, but the types can't reflect that
-		uint64(len(global))+uint64(len(local)),
-	)
-
-	ignores = append(ignores, global...)
-	ignores = append(ignores, local...)
-
-	return ignores
-}
-
 type lockfileAndConfigOrErr struct {
 	lockf  lockfile.Lockfile
 	config *configer.Config
@@ -497,13 +483,14 @@ func collectEcosystems(files []lockfileAndConfigOrErr) []internal.Ecosystem {
 }
 
 func run(args []string, stdout, stderr io.Writer) int {
-	var ignores stringsFlag
+	var globalIgnores stringsFlag
 	cli := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 	offline := cli.Bool("offline", false, "Perform checks using only the cached databases on disk")
 	parseAs := cli.String("parse-as", "", "Name of a supported lockfile to parse the input files as")
 	configPath := cli.String("config", "", "Path to a config file to use for all lockfiles")
 	noConfig := cli.Bool("no-config", false, "Disable loading of any config files")
+	noConfigIgnores := cli.Bool("no-config-ignores", false, "Don't respect any OSVs listed as ignored in configs")
 	printVersion := cli.Bool("version", false, "Print version information")
 	listEcosystems := cli.Bool("list-ecosystems", false, "List all of the known ecosystems that are supported by the detector")
 	listPackages := cli.Bool("list-packages", false, "List the packages that are parsed from the input files")
@@ -513,7 +500,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	useAPI := cli.Bool("use-api", false, "Use the osv.dev API to check for known vulnerabilities")
 	batchSize := cli.Int("batch-size", 1000, "The number of packages to include in each batch when using the api database")
 
-	cli.Var(&ignores, "ignore", `ID of an OSV to ignore when determining exit codes.
+	cli.Var(&globalIgnores, "ignore", `ID of an OSV to ignore when determining exit codes.
 This flag can be passed multiple times to ignore different vulnerabilities`)
 
 	// cli is set for ExitOnError so this will never return an error
@@ -623,6 +610,10 @@ This flag can be passed multiple times to ignore different vulnerabilities`)
 		config := result.config
 		lockf := result.lockf
 
+		if *noConfigIgnores {
+			config.Ignore = []string{}
+		}
+
 		r.PrintText(fmt.Sprintf(
 			"%s: found %s %s\n",
 			color.MagentaString("%s", lockf.FilePath),
@@ -636,17 +627,36 @@ This flag can be passed multiple times to ignore different vulnerabilities`)
 			continue
 		}
 
+
+		ignores := make(
+			[]string,
+			0,
+			// len cannot return negative numbers, but the types can't reflect that
+			uint64(len(globalIgnores))+uint64(len(config.Ignore)),
+		)
+
 		// an empty FilePath means we didn't load a config
 		if config.FilePath != "" {
+			var ignoresStr string
+
+			if *noConfigIgnores {
+				ignoresStr = "skipping any ignores"
+			} else {
+				ignores = append(ignores, config.Ignore...)
+				ignoresStr = color.YellowString("%d %s",
+					len(config.Ignore),
+					reporter.Form(len(config.Ignore), "ignore", "ignores"),
+				)
+			}
+
 			r.PrintText(fmt.Sprintf(
 				"  Using config at %s (%s)\n",
 				color.MagentaString(config.FilePath),
-				color.YellowString("%d %s",
-					len(config.Ignore),
-					reporter.Form(len(config.Ignore), "ignore", "ignores"),
-				),
+				ignoresStr,
 			))
 		}
+
+		ignores = append(ignores, globalIgnores...)
 
 		dbs := dbs.forConfigs(config.Databases)
 		for _, db := range dbs {
@@ -664,7 +674,7 @@ This flag can be passed multiple times to ignore different vulnerabilities`)
 		}
 		r.PrintText("\n")
 
-		report := dbs.check(r, lockf, allIgnores(config.Ignore, ignores))
+		report := dbs.check(r, lockf, ignores)
 
 		r.PrintResult(report)
 

--- a/main_test.go
+++ b/main_test.go
@@ -936,7 +936,77 @@ func TestRun_Ignores(t *testing.T) {
 			`,
 			wantStderr: "",
 		},
-		// ignores passed by flags are _merged_ with those specified in configs
+		// ignores passed by flags are _merged_ with those specified in configs by default
+		{
+			name: "",
+			args: []string{
+				"--config", "./fixtures/my-config.yml",
+				"--ignore", "GHSA-1234",
+				"--parse-as", "package-lock.json",
+				"./fixtures/locks-insecure/my-package-lock.json",
+			},
+			wantExitCode: 0,
+			wantStdout: `
+				Loaded the following OSV databases:
+					npm (%% vulnerabilities, including withdrawn - last updated %%)
+
+				fixtures/locks-insecure/my-package-lock.json: found 1 package
+					Using config at fixtures/my-config.yml (1 ignore)
+					Using db npm (%% vulnerabilities, including withdrawn - last updated %%)
+
+					no new vulnerabilities found (1 was ignored)
+			`,
+			wantStderr: "",
+		},
+		// ignores from configs are ignored if "--no-config-ignores" is passed
+		{
+			name: "",
+			args: []string{
+				"--no-config-ignores",
+				"--config", "./fixtures/my-config.yml",
+				"--parse-as", "package-lock.json",
+				"./fixtures/locks-insecure/my-package-lock.json",
+			},
+			wantExitCode: 1,
+			wantStdout: `
+				Loaded the following OSV databases:
+					npm (%% vulnerabilities, including withdrawn - last updated %%)
+
+				fixtures/locks-insecure/my-package-lock.json: found 1 package
+					Using config at fixtures/my-config.yml (skipping any ignores)
+					Using db npm (%% vulnerabilities, including withdrawn - last updated %%)
+
+					ansi-html@0.0.1 is affected by the following vulnerabilities:
+						GHSA-whgm-jr23-g3j9: Uncontrolled Resource Consumption in ansi-html (https://github.com/advisories/GHSA-whgm-jr23-g3j9)
+
+					1 known vulnerability found in fixtures/locks-insecure/my-package-lock.json
+			`,
+			wantStderr: "",
+		},
+		// ignores passed by flags are still respected with "--no-config-ignores"
+		{
+			name: "",
+			args: []string{
+				"--no-config-ignores",
+				"--config", "./fixtures/my-config.yml",
+				"--ignore", "GHSA-whgm-jr23-g3j9",
+				"--parse-as", "package-lock.json",
+				"./fixtures/locks-insecure/my-package-lock.json",
+			},
+			wantExitCode: 0,
+			wantStdout: `
+				Loaded the following OSV databases:
+					npm (%% vulnerabilities, including withdrawn - last updated %%)
+
+				fixtures/locks-insecure/my-package-lock.json: found 1 package
+					Using config at fixtures/my-config.yml (skipping any ignores)
+					Using db npm (%% vulnerabilities, including withdrawn - last updated %%)
+
+					no new vulnerabilities found (1 was ignored)
+			`,
+			wantStderr: "",
+		},
+		// ignores passed by flags are ignored with those specified in configs
 		{
 			name: "",
 			args: []string{

--- a/main_test.go
+++ b/main_test.go
@@ -752,6 +752,45 @@ func TestRun_Configs(t *testing.T) {
 			`,
 			wantStderr: " failed: unable to fetch OSV database: could not read OSV database archive: zip: not a valid zip file",
 		},
+		// databases from configs are ignored if "--no-config-databases" is passed...
+		{
+			name: "",
+			args: []string{
+				"--no-config-databases",
+				"./fixtures/configs-extra-dbs/yarn.lock",
+			},
+			wantExitCode: 0,
+			wantStdout: `
+				Loaded the following OSV databases:
+
+				fixtures/configs-extra-dbs/yarn.lock: found 0 packages
+					Using config at fixtures/configs-extra-dbs/.osv-detector.yaml (0 ignores)
+
+					no known vulnerabilities found
+			`,
+			wantStderr: "",
+		},
+		// ...but it does still use the built-in databases
+		{
+			name: "",
+			args: []string{
+				"--config", "./fixtures/configs-extra-dbs/.osv-detector.yaml",
+				"--no-config-databases",
+				"./fixtures/locks-many/yarn.lock",
+			},
+			wantExitCode: 0,
+			wantStdout: `
+				Loaded the following OSV databases:
+					npm (%% vulnerabilities, including withdrawn - last updated %%)
+
+				fixtures/locks-many/yarn.lock: found 1 package
+					Using config at fixtures/configs-extra-dbs/.osv-detector.yaml (0 ignores)
+					Using db npm (%% vulnerabilities, including withdrawn - last updated %%)
+
+					no known vulnerabilities found
+			`,
+			wantStderr: "",
+		},
 		// when a global config is provided, any local configs should be ignored
 		{
 			name:         "",


### PR DESCRIPTION
These flags are useful for automated tooling and those paranoid about downloading arbitrary zip files from untrusted sources. I'm still not labeling this a security issue because there has to be another step to allow getting the config file to the detector in the first place which either means you trust the source enough to explicitly pull in its config (e.g. with a `git clone`) or you've already been compromised (in which case its a moot point).

Resolves #136
Resolves #133