### PR TITLE
feat: support `last_affected` in OSVs

### DIFF
--- a/pkg/database/osv.go
+++ b/pkg/database/osv.go
@@ -48,8 +48,9 @@ func (p Package) NormalizedName() string {
 }
 
 type RangeEvent struct {
-	Introduced string `json:"introduced,omitempty"`
-	Fixed      string `json:"fixed,omitempty"`
+	Introduced   string `json:"introduced,omitempty"`
+	Fixed        string `json:"fixed,omitempty"`
+	LastAffected string `json:"last_affected,omitempty"`
 }
 
 type AffectsRange struct {
@@ -70,10 +71,14 @@ func (ar AffectsRange) containsVersion(v string) bool {
 
 	var affected bool
 	for _, e := range ar.Events {
-		if !affected && e.Introduced != "" {
+		if affected {
+			if e.Fixed != "" {
+				affected = vp.CompareStr(e.Fixed) < 0
+			} else if e.LastAffected != "" {
+				affected = e.LastAffected == v || vp.CompareStr(e.LastAffected) <= 0
+			}
+		} else if e.Introduced != "" {
 			affected = e.Introduced == "0" || vp.CompareStr(e.Introduced) >= 0
-		} else if affected && e.Fixed != "" {
-			affected = vp.CompareStr(e.Fixed) < 0
 		}
 	}
 


### PR DESCRIPTION
See https://github.com/ossf/osv-schema/issues/35

I think I've implemented this correctly but it's a little hard to tell for sure until someone actually creates OSVs with it 😅 

Resolves #140 