### PR TITLE
Update parsers map to correct cargo.lock to Cargo.lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The detector supports parsing the following lockfiles:
 
 | Lockfile             | Ecosystem   | Tool       |
 | -------------------- | ----------- | ---------- |
-| `cargo.lock`         | `crates.io` | `cargo`    |
+| `Cargo.lock`         | `crates.io` | `cargo`    |
 | `package-lock.json`  | `npm`       | `npm`      |
 | `yarn.lock`          | `npm`       | `yarn`     |
 | `pnpm-lock.yaml`     | `npm`       | `pnpm`     |

--- a/main_test.go
+++ b/main_test.go
@@ -122,7 +122,7 @@ func TestRun(t *testing.T) {
 			wantStdout:   "",
 			wantStderr: `
 				Don't know how to parse files as "my-file" - supported values are:
-					cargo.lock
+					Cargo.lock
 					composer.lock
 					Gemfile.lock
 					go.mod

--- a/pkg/lockfile/parse.go
+++ b/pkg/lockfile/parse.go
@@ -18,7 +18,7 @@ func FindParser(pathToLockfile string, parseAs string) (PackageDetailsParser, st
 
 // nolint:gochecknoglobals // this is an optimisation and read-only
 var parsers = map[string]PackageDetailsParser{
-	"cargo.lock":        ParseCargoLock,
+	"Cargo.lock":        ParseCargoLock,
 	"composer.lock":     ParseComposerLock,
 	"Gemfile.lock":      ParseGemfileLock,
 	"go.mod":            ParseGoLock,

--- a/pkg/lockfile/parse_test.go
+++ b/pkg/lockfile/parse_test.go
@@ -40,7 +40,7 @@ func TestFindParser(t *testing.T) {
 	t.Parallel()
 
 	lockfiles := []string{
-		"cargo.lock",
+		"Cargo.lock",
 		"package-lock.json",
 		"yarn.lock",
 		"pnpm-lock.yaml",
@@ -82,7 +82,7 @@ func TestParse_FindsExpectedParsers(t *testing.T) {
 	t.Parallel()
 
 	lockfiles := []string{
-		"cargo.lock",
+		"Cargo.lock",
 		"package-lock.json",
 		"yarn.lock",
 		"pnpm-lock.yaml",
@@ -128,8 +128,8 @@ func TestListParsers(t *testing.T) {
 
 	parsers := lockfile.ListParsers()
 
-	if first := parsers[0]; first != "cargo.lock" {
-		t.Errorf("Expected first element to be cargo.lock, but got %s", first)
+	if first := parsers[0]; first != "Cargo.lock" {
+		t.Errorf("Expected first element to be Cargo.lock, but got %s", first)
 	}
 
 	if last := parsers[len(parsers)-1]; last != "yarn.lock" {


### PR DESCRIPTION
`cargo` lockfiles starts with a capital letter: https://doc.rust-lang.org/cargo/appendix/glossary.html

The current parsers map has `cargo.lock`, which means it fails to find a parser when pointed to a standard cargo lock file, this PR just replaces all instances of `cargo.lock` with `Cargo.lock`. All tests still seem to pass.