### PR TITLE
fix: switch to using `big.Int` in version parsing & comparing to support really large numbers

### DIFF
--- a/pkg/semantic/compare.go
+++ b/pkg/semantic/compare.go
@@ -1,8 +1,8 @@
 package semantic
 
 import (
+	"math/big"
 	"regexp"
-	"strconv"
 )
 
 func maxInt(x, y int) int {
@@ -13,23 +13,11 @@ func maxInt(x, y int) int {
 	return x
 }
 
-func compareInt(a int, b int) int {
-	if a == b {
-		return 0
-	}
-
-	if a < b {
-		return -1
-	}
-
-	return +1
-}
-
 func compareComponents(a Components, b Components) int {
 	numberOfComponents := maxInt(len(a), len(b))
 
 	for i := 0; i < numberOfComponents; i++ {
-		diff := compareInt(a.Fetch(i), b.Fetch(i))
+		diff := a.Fetch(i).Cmp(b.Fetch(i))
 
 		if diff != 0 {
 			return diff
@@ -39,16 +27,18 @@ func compareComponents(a Components, b Components) int {
 	return 0
 }
 
-func tryExtractNumber(str string) int {
+func tryExtractNumber(str string) *big.Int {
 	matcher := regexp.MustCompile(`[a-zA-Z.-]+(\d+)`)
 
 	results := matcher.FindStringSubmatch(str)
 
 	if results == nil {
-		return 0
+		return big.NewInt(0)
 	}
 
-	r, _ := strconv.Atoi(results[1])
+	// it should not be possible for this to not be a number,
+	// because we select only numbers above in our regexp
+	r, _ := new(big.Int).SetString(results[1], 10)
 
 	return r
 }
@@ -64,7 +54,7 @@ func compareBuilds(a string, b string) int {
 	av := tryExtractNumber(a)
 	bv := tryExtractNumber(b)
 
-	return compareInt(av, bv)
+	return av.Cmp(bv)
 }
 
 // Compare returns an integer comparing two versions according to

--- a/pkg/semantic/parse.go
+++ b/pkg/semantic/parse.go
@@ -1,13 +1,13 @@
 package semantic
 
 import (
+	"math/big"
 	"regexp"
-	"strconv"
 	"strings"
 )
 
 func Parse(line string) Version {
-	var components []int
+	var components []*big.Int
 
 	numberReg := regexp.MustCompile(`\d`)
 
@@ -43,7 +43,7 @@ func Parse(line string) Version {
 		// either way, we will be terminating the current component being
 		// parsed (if any), so let's do that first
 		if currentCom != "" {
-			v, _ := strconv.Atoi(currentCom)
+			v, _ := new(big.Int).SetString(currentCom, 10)
 
 			components = append(components, v)
 			currentCom = ""
@@ -67,7 +67,7 @@ func Parse(line string) Version {
 	// if we looped over everything without finding a build string,
 	// then what we were currently parsing is actually a component
 	if !foundBuild && currentCom != "" {
-		v, _ := strconv.Atoi(currentCom)
+		v, _ := new(big.Int).SetString(currentCom, 10)
 
 		components = append(components, v)
 		currentCom = ""

--- a/pkg/semantic/parse_test.go
+++ b/pkg/semantic/parse_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"github.com/g-rath/osv-detector/pkg/semantic"
+	"math/big"
 	"os"
 	"strings"
 	"testing"
@@ -19,12 +20,24 @@ func versionsEqual(expectedVersion semantic.Version, actualVersion semantic.Vers
 	}
 
 	for i := range expectedVersion.Components {
-		if expectedVersion.Components[i] != actualVersion.Components[i] {
+		if expectedVersion.Components[i].Cmp(actualVersion.Components[i]) != 0 {
 			return false
 		}
 	}
 
 	return true
+}
+
+func asBigInts(t *testing.T, components ...int) []*big.Int {
+	t.Helper()
+
+	comps := make([]*big.Int, 0, len(components))
+
+	for _, i := range components {
+		comps = append(comps, big.NewInt(int64(i)))
+	}
+
+	return comps
 }
 
 func explainVersion(version semantic.Version) string {
@@ -103,43 +116,43 @@ func TestParse_Standard(t *testing.T) {
 
 	expectParsedAsVersion(t, "0.0.0.0", semantic.Version{
 		LeadingV:   false,
-		Components: []int{0, 0, 0, 0},
+		Components: asBigInts(t, 0, 0, 0, 0),
 		Build:      "",
 	})
 
 	expectParsedAsVersion(t, "1.0.0.0", semantic.Version{
 		LeadingV:   false,
-		Components: []int{1, 0, 0, 0},
+		Components: asBigInts(t, 1, 0, 0, 0),
 		Build:      "",
 	})
 
 	expectParsedAsVersion(t, "1.2.0.0", semantic.Version{
 		LeadingV:   false,
-		Components: []int{1, 2, 0, 0},
+		Components: asBigInts(t, 1, 2, 0, 0),
 		Build:      "",
 	})
 
 	expectParsedAsVersion(t, "1.2.3.0", semantic.Version{
 		LeadingV:   false,
-		Components: []int{1, 2, 3, 0},
+		Components: asBigInts(t, 1, 2, 3, 0),
 		Build:      "",
 	})
 
 	expectParsedAsVersion(t, "1.2.3.4", semantic.Version{
 		LeadingV:   false,
-		Components: []int{1, 2, 3, 4},
+		Components: asBigInts(t, 1, 2, 3, 4),
 		Build:      "",
 	})
 
 	expectParsedAsVersion(t, "9.2.55826.0", semantic.Version{
 		LeadingV:   false,
-		Components: []int{9, 2, 55826, 0},
+		Components: asBigInts(t, 9, 2, 55826, 0),
 		Build:      "",
 	})
 
 	expectParsedAsVersion(t, "3.2.22.3", semantic.Version{
 		LeadingV:   false,
-		Components: []int{3, 2, 22, 3},
+		Components: asBigInts(t, 3, 2, 22, 3),
 		Build:      "",
 	})
 }
@@ -149,25 +162,25 @@ func TestParse_Omitted(t *testing.T) {
 
 	expectParsedAsVersion(t, "1", semantic.Version{
 		LeadingV:   false,
-		Components: []int{1},
+		Components: asBigInts(t, 1),
 		Build:      "",
 	})
 
 	expectParsedAsVersion(t, "1.2", semantic.Version{
 		LeadingV:   false,
-		Components: []int{1, 2},
+		Components: asBigInts(t, 1, 2),
 		Build:      "",
 	})
 
 	expectParsedAsVersion(t, "1.2.3", semantic.Version{
 		LeadingV:   false,
-		Components: []int{1, 2, 3},
+		Components: asBigInts(t, 1, 2, 3),
 		Build:      "",
 	})
 
 	expectParsedAsVersion(t, "1.2.3.", semantic.Version{
 		LeadingV:   false,
-		Components: []int{1, 2, 3},
+		Components: asBigInts(t, 1, 2, 3),
 		Build:      ".",
 	})
 }
@@ -177,49 +190,49 @@ func TestParse_WithBuildString(t *testing.T) {
 
 	expectParsedAsVersion(t, "10.0.0.beta1", semantic.Version{
 		LeadingV:   false,
-		Components: []int{10, 0, 0},
+		Components: asBigInts(t, 10, 0, 0),
 		Build:      ".beta1",
 	})
 
 	expectParsedAsVersion(t, "1.0.0a20", semantic.Version{
 		LeadingV:   false,
-		Components: []int{1, 0, 0},
+		Components: asBigInts(t, 1, 0, 0),
 		Build:      "a20",
 	})
 
 	expectParsedAsVersion(t, "9.0.0.pre1", semantic.Version{
 		LeadingV:   false,
-		Components: []int{9, 0, 0},
+		Components: asBigInts(t, 9, 0, 0),
 		Build:      ".pre1",
 	})
 
 	expectParsedAsVersion(t, "9.4.16.v20190411", semantic.Version{
 		LeadingV:   false,
-		Components: []int{9, 4, 16},
+		Components: asBigInts(t, 9, 4, 16),
 		Build:      ".v20190411",
 	})
 
 	expectParsedAsVersion(t, "0.3.0-beta.83", semantic.Version{
 		LeadingV:   false,
-		Components: []int{0, 3, 0},
+		Components: asBigInts(t, 0, 3, 0),
 		Build:      "-beta.83",
 	})
 
 	expectParsedAsVersion(t, "3.0.0-beta.17.5", semantic.Version{
 		LeadingV:   false,
-		Components: []int{3, 0, 0},
+		Components: asBigInts(t, 3, 0, 0),
 		Build:      "-beta.17.5",
 	})
 
 	expectParsedAsVersion(t, "4.0.0-milestone3", semantic.Version{
 		LeadingV:   false,
-		Components: []int{4, 0, 0},
+		Components: asBigInts(t, 4, 0, 0),
 		Build:      "-milestone3",
 	})
 
 	expectParsedAsVersion(t, "13.6RC1", semantic.Version{
 		LeadingV:   false,
-		Components: []int{13, 6},
+		Components: asBigInts(t, 13, 6),
 		Build:      "RC1",
 	})
 }
@@ -263,19 +276,19 @@ func TestParse_LeadingV(t *testing.T) {
 
 	expectParsedVersionToMatchString(t, "v1.0.0", "v1.0.0", semantic.Version{
 		LeadingV:   true,
-		Components: []int{1, 0, 0},
+		Components: asBigInts(t, 1, 0, 0),
 		Build:      "",
 	})
 
 	expectParsedVersionToMatchString(t, "v1.2.3-beta1", "v1.2.3-beta1", semantic.Version{
 		LeadingV:   true,
-		Components: []int{1, 2, 3},
+		Components: asBigInts(t, 1, 2, 3),
 		Build:      "-beta1",
 	})
 
 	expectParsedVersionToMatchString(t, "version210", "version210", semantic.Version{
 		LeadingV:   false,
-		Components: []int{},
+		Components: asBigInts(t, ),
 		Build:      "version210",
 	})
 }
@@ -285,13 +298,13 @@ func TestParse_LeadingZerosAndDateLike(t *testing.T) {
 
 	expectParsedVersionToMatchString(t, "20.04.0", "20.4.0", semantic.Version{
 		LeadingV:   false,
-		Components: []int{20, 4, 0},
+		Components: asBigInts(t, 20, 4, 0),
 		Build:      "",
 	})
 
 	expectParsedVersionToMatchString(t, "4.3.04", "4.3.4", semantic.Version{
 		LeadingV:   false,
-		Components: []int{4, 3, 4},
+		Components: asBigInts(t, 4, 3, 4),
 		Build:      "",
 	})
 }
@@ -308,37 +321,37 @@ func TestParse_DateLike(t *testing.T) {
 
 	expectParsedVersionToMatchString(t, "20.04.0", "20.4.0", semantic.Version{
 		LeadingV:   false,
-		Components: []int{20, 4, 0},
+		Components: asBigInts(t, 20, 4, 0),
 		Build:      "",
 	})
 
 	expectParsedVersionToMatchString(t, "4.3.04alpha01", "4.3.4alpha01", semantic.Version{
 		LeadingV:   false,
-		Components: []int{4, 3, 4},
+		Components: asBigInts(t, 4, 3, 4),
 		Build:      "alpha01",
 	})
 
 	expectParsedVersionToMatchString(t, "2019.03.6.1", "2019.3.6.1", semantic.Version{
 		LeadingV:   false,
-		Components: []int{2019, 3, 6, 1},
+		Components: asBigInts(t, 2019, 3, 6, 1),
 		Build:      "",
 	})
 
 	expectParsedVersionToMatchString(t, "19.04.15", "19.4.15", semantic.Version{
 		LeadingV:   false,
-		Components: []int{19, 4, 15},
+		Components: asBigInts(t, 19, 4, 15),
 		Build:      "",
 	})
 
 	expectParsedVersionToMatchString(t, "20.04.13", "20.4.13", semantic.Version{
 		LeadingV:   false,
-		Components: []int{20, 4, 13},
+		Components: asBigInts(t, 20, 4, 13),
 		Build:      "",
 	})
 
 	expectParsedVersionToMatchString(t, "2019.11.09", "2019.11.9", semantic.Version{
 		LeadingV:   false,
-		Components: []int{2019, 11, 9},
+		Components: asBigInts(t, 2019, 11, 9),
 		Build:      "",
 	})
 }

--- a/pkg/semantic/version.go
+++ b/pkg/semantic/version.go
@@ -2,10 +2,11 @@ package semantic
 
 import (
 	"fmt"
+	"math/big"
 	"strings"
 )
 
-type Components []int
+type Components []*big.Int
 
 type Version struct {
 	LeadingV   bool
@@ -13,9 +14,9 @@ type Version struct {
 	Build      string
 }
 
-func (components *Components) Fetch(n int) int {
+func (components *Components) Fetch(n int) *big.Int {
 	if len(*components) <= n {
-		return 0
+		return big.NewInt(0)
 	}
 
 	return (*components)[n]


### PR DESCRIPTION
I realised this when working on an overhaul of `semantic` that switches it to use ecosystem-specific comparators for better accuracy.

While I'm almost done with that work, landing this first would make the diff a little smaller and this is technically a bug anyway.

@another-rex I'm pretty sure this won't impact you because you're currently just using `lockfiles` but heads up all the same just in case :)