### PR TITLE
chore: enable `gofmt` formatter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,8 @@
 output:
   sort-results: true
 linters:
+  enable:
+    - gofmt
   # prettier-ignore
   disable:
     - tagliatelle      # we're parsing data from external sources

--- a/main.go
+++ b/main.go
@@ -624,7 +624,6 @@ This flag can be passed multiple times to ignore different vulnerabilities`)
 			continue
 		}
 
-
 		ignores := make(
 			[]string,
 			0,

--- a/pkg/database/mem-check.go
+++ b/pkg/database/mem-check.go
@@ -7,7 +7,7 @@ import (
 // an OSV database that lives in-memory, and can be used by other structs
 // that handle loading the vulnerabilities from where ever
 type memDB struct {
-	vulnerabilities  []OSV
+	vulnerabilities []OSV
 }
 
 func (db *memDB) Vulnerabilities(includeWithdrawn bool) []OSV {

--- a/pkg/semantic/parse_test.go
+++ b/pkg/semantic/parse_test.go
@@ -288,7 +288,7 @@ func TestParse_LeadingV(t *testing.T) {
 
 	expectParsedVersionToMatchString(t, "version210", "version210", semantic.Version{
 		LeadingV:   false,
-		Components: asBigInts(t, ),
+		Components: asBigInts(t),
 		Build:      "version210",
 	})
 }


### PR DESCRIPTION
I didn't realise that this wasn't actually being checked by CI/linting 😬 