### PR TITLE
refactor: move off deprecated `io/ioutil` methods, use `http` method constants, and adjust lint comments

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,6 +18,7 @@ linters:
     - godot            # comments are fine without full stops
     - gomnd            # not every number is magic
     - wsl              # disagree with, for now
+    - ireturn          # disagree with, sort of
   presets:
     - bugs
     - comment

--- a/internal/configer/load_test.go
+++ b/internal/configer/load_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-// nolint:unparam
+//nolint:unparam
 func newReporter(t *testing.T) (*reporter.Reporter, *bytes.Buffer, *bytes.Buffer) {
 	t.Helper()
 
@@ -164,7 +164,7 @@ func TestLoad(t *testing.T) {
 	}
 
 	if isMissingStderrMessage {
-		// nolint:forbidigo
+		//nolint:forbidigo
 		fmt.Println(gotStderr)
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,4 @@
-// nolint:testpackage // main cannot be accessed directly, so cannot use main_test
+//nolint:testpackage // main cannot be accessed directly, so cannot use main_test
 package main
 
 import (

--- a/pkg/database/api-check.go
+++ b/pkg/database/api-check.go
@@ -64,7 +64,7 @@ func (db APIDB) checkBatch(pkgs []internal.PackageDetails) ([][]ObjectWithID, er
 
 	req, err := http.NewRequestWithContext(
 		context.Background(),
-		"POST",
+		http.MethodPost,
 		db.bulkEndpoint(),
 		bytes.NewBuffer(jsonData),
 	)

--- a/pkg/database/api-check_test.go
+++ b/pkg/database/api-check_test.go
@@ -51,7 +51,7 @@ func jsonMarshalQueryBatchResponse(t *testing.T, vulns []objectsWithIDs) []byte 
 func expectRequestPayload(t *testing.T, r *http.Request, queries []apiQuery) {
 	t.Helper()
 
-	if r.Method != "POST" {
+	if r.Method != http.MethodPost {
 		t.Fatalf("api query was not a POST request")
 	}
 

--- a/pkg/database/api-fetch.go
+++ b/pkg/database/api-fetch.go
@@ -23,7 +23,7 @@ func (db APIDB) Fetch(id string) (OSV, error) {
 
 	req, err := http.NewRequestWithContext(
 		context.Background(),
-		"GET",
+		http.MethodGet,
 		db.osvEndpoint(id),
 		http.NoBody,
 	)

--- a/pkg/database/config.go
+++ b/pkg/database/config.go
@@ -27,7 +27,6 @@ func (dbc Config) Identifier() string {
 var ErrUnsupportedDatabaseType = errors.New("unsupported database source type")
 
 // Load initializes a new OSV database based on the given Config
-//nolint:ireturn
 func Load(config Config, offline bool, batchSize int) (DB, error) {
 	switch config.Type {
 	case "zip":

--- a/pkg/database/config.go
+++ b/pkg/database/config.go
@@ -27,7 +27,7 @@ func (dbc Config) Identifier() string {
 var ErrUnsupportedDatabaseType = errors.New("unsupported database source type")
 
 // Load initializes a new OSV database based on the given Config
-// nolint:ireturn
+//nolint:ireturn
 func Load(config Config, offline bool, batchSize int) (DB, error) {
 	switch config.Type {
 	case "zip":

--- a/pkg/database/zip.go
+++ b/pkg/database/zip.go
@@ -112,7 +112,7 @@ func (db *ZipDB) fetchZip() ([]byte, error) {
 	cacheContents, err := json.Marshal(cache)
 
 	if err == nil {
-		// nolint:gosec // being world readable is fine
+		//nolint:gosec // being world readable is fine
 		err = os.WriteFile(cachePath, cacheContents, 0644)
 
 		if err != nil {

--- a/pkg/database/zip.go
+++ b/pkg/database/zip.go
@@ -68,7 +68,7 @@ func (db *ZipDB) fetchZip() ([]byte, error) {
 		return cache.Body, nil
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), "GET", db.ArchiveURL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, db.ArchiveURL, nil)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve OSV database archive: %w", err)

--- a/pkg/database/zip_test.go
+++ b/pkg/database/zip_test.go
@@ -55,7 +55,7 @@ func cacheWrite(t *testing.T, cache database.Cache) {
 	cacheContents, err := json.Marshal(cache)
 
 	if err == nil {
-		// nolint:gosec // being world readable is fine
+		//nolint:gosec // being world readable is fine
 		err = os.WriteFile(cachePath(cache.URL), cacheContents, 0644)
 	}
 
@@ -67,7 +67,7 @@ func cacheWrite(t *testing.T, cache database.Cache) {
 func cacheWriteBad(t *testing.T, url string, contents string) {
 	t.Helper()
 
-	// nolint:gosec // being world readable is fine
+	//nolint:gosec // being world readable is fine
 	err := os.WriteFile(cachePath(url), []byte(contents), 0644)
 
 	if err != nil {

--- a/pkg/lockfile/ecosystems_test.go
+++ b/pkg/lockfile/ecosystems_test.go
@@ -2,7 +2,7 @@ package lockfile_test
 
 import (
 	"github.com/g-rath/osv-detector/pkg/lockfile"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 )
@@ -10,7 +10,7 @@ import (
 func numberOfLockfileParsers(t *testing.T) int {
 	t.Helper()
 
-	directories, err := ioutil.ReadDir(".")
+	directories, err := os.ReadDir(".")
 
 	if err != nil {
 		t.Fatalf("unable to read current directory: ")

--- a/pkg/lockfile/parse-cargo-lock.go
+++ b/pkg/lockfile/parse-cargo-lock.go
@@ -3,7 +3,7 @@ package lockfile
 import (
 	"fmt"
 	"github.com/BurntSushi/toml"
-	"io/ioutil"
+	"os"
 )
 
 type CargoLockPackage struct {
@@ -21,7 +21,7 @@ const CargoEcosystem Ecosystem = "crates.io"
 func ParseCargoLock(pathToLockfile string) ([]PackageDetails, error) {
 	var parsedLockfile *CargoLockFile
 
-	lockfileContents, err := ioutil.ReadFile(pathToLockfile)
+	lockfileContents, err := os.ReadFile(pathToLockfile)
 
 	if err != nil {
 		return []PackageDetails{}, fmt.Errorf("could not read %s: %w", pathToLockfile, err)

--- a/pkg/lockfile/parse-composer-lock.go
+++ b/pkg/lockfile/parse-composer-lock.go
@@ -3,7 +3,7 @@ package lockfile
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 type ComposerPackage struct {
@@ -24,7 +24,7 @@ const ComposerEcosystem Ecosystem = "Packagist"
 func ParseComposerLock(pathToLockfile string) ([]PackageDetails, error) {
 	var parsedLockfile *ComposerLock
 
-	lockfileContents, err := ioutil.ReadFile(pathToLockfile)
+	lockfileContents, err := os.ReadFile(pathToLockfile)
 
 	if err != nil {
 		return []PackageDetails{}, fmt.Errorf("could not read %s: %w", pathToLockfile, err)

--- a/pkg/lockfile/parse-gemfile-lock.go
+++ b/pkg/lockfile/parse-gemfile-lock.go
@@ -2,8 +2,8 @@ package lockfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"regexp"
 	"strings"
 )
@@ -165,7 +165,7 @@ func (parser *gemfileLockfileParser) parse(contents string) {
 func ParseGemfileLock(pathToLockfile string) ([]PackageDetails, error) {
 	var parser gemfileLockfileParser
 
-	bytes, err := ioutil.ReadFile(pathToLockfile)
+	bytes, err := os.ReadFile(pathToLockfile)
 
 	if err != nil {
 		return []PackageDetails{}, fmt.Errorf("could not read %s: %w", pathToLockfile, err)

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -3,14 +3,14 @@ package lockfile
 import (
 	"fmt"
 	"golang.org/x/mod/modfile"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
 const GoEcosystem Ecosystem = "Go"
 
 func ParseGoLock(pathToLockfile string) ([]PackageDetails, error) {
-	lockfileContents, err := ioutil.ReadFile(pathToLockfile)
+	lockfileContents, err := os.ReadFile(pathToLockfile)
 
 	if err != nil {
 		return []PackageDetails{}, fmt.Errorf("could not read %s: %w", pathToLockfile, err)

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -3,7 +3,6 @@ package lockfile
 import (
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 )
@@ -96,7 +95,7 @@ func (p *MavenLockProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElemen
 func ParseMavenLock(pathToLockfile string) ([]PackageDetails, error) {
 	var parsedLockfile *MavenLockFile
 
-	lockfileContents, err := ioutil.ReadFile(pathToLockfile)
+	lockfileContents, err := os.ReadFile(pathToLockfile)
 
 	if err != nil {
 		return []PackageDetails{}, fmt.Errorf("could not read %s: %w", pathToLockfile, err)

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -3,7 +3,7 @@ package lockfile
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 )
@@ -143,7 +143,7 @@ func parseNpmLock(lockfile NpmLockfile) map[string]PackageDetails {
 func ParseNpmLock(pathToLockfile string) ([]PackageDetails, error) {
 	var parsedLockfile *NpmLockfile
 
-	lockfileContents, err := ioutil.ReadFile(pathToLockfile)
+	lockfileContents, err := os.ReadFile(pathToLockfile)
 
 	if err != nil {
 		return []PackageDetails{}, fmt.Errorf("could not read %s: %w", pathToLockfile, err)

--- a/pkg/lockfile/parse-pnpm-lock.go
+++ b/pkg/lockfile/parse-pnpm-lock.go
@@ -3,7 +3,7 @@ package lockfile
 import (
 	"fmt"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 )
@@ -116,7 +116,7 @@ func parsePnpmLock(lockfile PnpmLockfile) []PackageDetails {
 func ParsePnpmLock(pathToLockfile string) ([]PackageDetails, error) {
 	var parsedLockfile *PnpmLockfile
 
-	lockfileContents, err := ioutil.ReadFile(pathToLockfile)
+	lockfileContents, err := os.ReadFile(pathToLockfile)
 
 	if err != nil {
 		return []PackageDetails{}, fmt.Errorf("could not read %s: %w", pathToLockfile, err)

--- a/pkg/lockfile/parse.go
+++ b/pkg/lockfile/parse.go
@@ -16,7 +16,7 @@ func FindParser(pathToLockfile string, parseAs string) (PackageDetailsParser, st
 	return parsers[parseAs], parseAs
 }
 
-// nolint:gochecknoglobals // this is an optimisation and read-only
+//nolint:gochecknoglobals // this is an optimisation and read-only
 var parsers = map[string]PackageDetailsParser{
 	"Cargo.lock":        ParseCargoLock,
 	"composer.lock":     ParseComposerLock,

--- a/pkg/lockfile/parse_test.go
+++ b/pkg/lockfile/parse_test.go
@@ -3,7 +3,7 @@ package lockfile_test
 import (
 	"errors"
 	"github.com/g-rath/osv-detector/pkg/lockfile"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -12,7 +12,7 @@ import (
 func expectNumberOfParsersCalled(t *testing.T, numberOfParsersCalled int) {
 	t.Helper()
 
-	directories, err := ioutil.ReadDir(".")
+	directories, err := os.ReadDir(".")
 
 	if err != nil {
 		t.Fatalf("unable to read current directory: ")


### PR DESCRIPTION
This is effectively a "backport" of changes that will be required when upgrading `golangci-lint` to v1.49.0 - I've not upgraded to it yet because it requires Go 1.19 and that adds an extra ~200kb to our binary size which I don't feel like taking on just yet.

This also disables `ireturn` because it's not bring me joy; that was cherry-picked from #157.