### PR TITLE
test: add cases for `semantic.MustParse`

### DIFF
--- a/pkg/semantic/parse_test.go
+++ b/pkg/semantic/parse_test.go
@@ -20,3 +20,30 @@ func TestParse(t *testing.T) {
 		}
 	}
 }
+
+func TestMustParse(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("unexpected panic - '%s'", r)
+		}
+	}()
+
+	ecosystems := lockfile.KnownEcosystems()
+
+	for _, ecosystem := range ecosystems {
+		semantic.MustParse("", ecosystem)
+	}
+}
+
+func TestMustParse_Panic(t *testing.T) {
+	t.Parallel()
+
+	defer func() { _ = recover() }()
+
+	semantic.MustParse("", "<unknown>")
+
+	// if we reached here, then we can't have panicked
+	t.Errorf("function did not panic when given an unknown ecosystem")
+}


### PR DESCRIPTION
Gets us a bit of extra coverage