### PR TITLE
chore: update linter

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.44
+          version: v1.47
   go-fmt:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,7 @@ linters:
     - tagliatelle      # we're parsing data from external sources
     - varnamelen       # maybe later
     - exhaustivestruct # overkill
+    - exhaustruct      # overkill
     - forcetypeassert  # too hard
     - interfacer       # deprecated
     - golint           # deprecated
@@ -19,6 +20,7 @@ linters:
     - gomnd            # not every number is magic
     - wsl              # disagree with, for now
     - ireturn          # disagree with, sort of
+    - nonamedreturns   # they have their uses
   presets:
     - bugs
     - comment

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test-with-coverage:
 lint:	lint-with-golangci-lint lint-with-go-fmt
 
 lint-with-golangci-lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2 run ./... --max-same-issues 0
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3 run ./... --max-same-issues 0
 
 lint-with-go-fmt:
 	gofmt -s -d */**.go

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // main cannot be accessed directly, so cannot use main_test
 package main
 
 import (


### PR DESCRIPTION
This is the highest version we can use without upgrading the go version itself, which I've not got a strong reason to do just yet, but am doing some experimental stuff that requires go v1.19+ and reduces the amount of work I have to do in that branch.