### PR TITLE
fix: avoid panic when parsing `file:` dependencies in `pnpm` lockfiles

### DIFF
--- a/pkg/lockfile/fixtures/pnpm/files.yaml
+++ b/pkg/lockfile/fixtures/pnpm/files.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   my-file-package: file:./projects/package-a.tgz
@@ -16,5 +16,32 @@ packages:
   file:../a-local-package:
     resolution: {directory: ../local-package, type: directory}
     name: a-local-package
+    version: 1.0.0
+    dev: false
+
+  file:../a-local-package/nested:
+    resolution: {directory: ../a-local-package/nested, type: directory}
+    name: a-nested-local-package
+    version: 1.0.0
+    dev: false
+
+  file:..:
+    resolution: {directory: .., type: directory}
+    name: one-up
+    version: 1.0.0
+    dev: false
+
+  file:.._react-dom@18.2.0:
+    resolution: {directory: .., type: directory}
+    name: one-up-with-peer
+    version: 1.0.0
+    dev: false
+    peerDependencies:
+      react-dom: ^18.0.0
+
+  # file based dependencies must always have a name so this is impossible,
+  # but we want to ensure we don't panic just in case
+  file:../nameless-package:
+    resolution: {directory: ../nameless-package, type: directory}
     version: 1.0.0
     dev: false

--- a/pkg/lockfile/parse-pnpm-lock.go
+++ b/pkg/lockfile/parse-pnpm-lock.go
@@ -37,6 +37,13 @@ func startsWithNumber(str string) bool {
 // extractPnpmPackageNameAndVersion parses a dependency path, attempting to
 // extract the name and version of the package it represents
 func extractPnpmPackageNameAndVersion(dependencyPath string) (string, string) {
+	// file dependencies must always have a name property to be installed,
+	// and their dependency path never has the version encoded, so we can
+	// skip trying to extract either from their dependency path
+	if strings.HasPrefix(dependencyPath, "file:") {
+		return "", ""
+	}
+
 	parts := strings.Split(dependencyPath, "/")
 	var name string
 

--- a/pkg/lockfile/parse-pnpm-lock_test.go
+++ b/pkg/lockfile/parse-pnpm-lock_test.go
@@ -459,5 +459,26 @@ func TestParsePnpmLock_Files(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
 		},
+		{
+			Name:      "a-nested-local-package",
+			Version:   "1.0.0",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			Commit:    "",
+		},
+		{
+			Name:      "one-up",
+			Version:   "1.0.0",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			Commit:    "",
+		},
+		{
+			Name:      "one-up-with-peer",
+			Version:   "1.0.0",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			Commit:    "",
+		},
 	})
 }


### PR DESCRIPTION
Turns out `..` is a thing, but then actually we shouldn't be doing any dependency path parsing for `file:` dependencies