### PR TITLE
fix: trim leading zeros off when comparing numerical components in Maven versions

### DIFF
--- a/pkg/semantic/fixtures/maven-versions.txt
+++ b/pkg/semantic/fixtures/maven-versions.txt
@@ -33,6 +33,9 @@
 1 = 1-0
 1 = 1.0-0
 1.0 = 1.0-0
+
+1.1 = 1.01
+
 // no separator between number and character
 1a = 1-a
 1a = 1.0-a

--- a/pkg/semantic/version-maven.go
+++ b/pkg/semantic/version-maven.go
@@ -40,7 +40,18 @@ func (vt *mavenVersionToken) shouldTrim() bool {
 }
 
 func (vt *mavenVersionToken) equal(wt mavenVersionToken) bool {
-	return vt.prefix == wt.prefix && vt.value == wt.value
+	if vt.prefix != wt.prefix {
+		return false
+	}
+
+	vv, vIsNumber := convertToBigInt(vt.value)
+	wv, wIsNumber := convertToBigInt(wt.value)
+
+	if vIsNumber && wIsNumber {
+		return vv.Cmp(wv) == 0
+	}
+
+	return vt.value == wt.value
 }
 
 //nolint:gochecknoglobals // this is read-only and the nicest implementation


### PR DESCRIPTION
Found after regenerating the generated list of maven versions