### PR TITLE
ci: setup workflow for running `semantic` fixture generators regularly

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -14,6 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - uses: actions/cache/restore@v3
+        with:
+          path: /tmp/debian-versions-generator-cache.csv
+          key: ${{ runner.os }}-
+
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - uses: actions/setup-python@v4
@@ -21,10 +28,16 @@ jobs:
           python-version: '3.10'
       - run: dpkg --version
       - run: python3 generators/generate-debian-versions.py
+      - run: stat debian-db.zip
       - uses: actions/upload-artifact@v3
         with:
           name: generated-versions
           path: pkg/semantic/fixtures/debian-versions-generated.txt
+
+      - uses: actions/cache/save@v3
+        with:
+          path: /tmp/debian-versions-generator-cache.csv
+          key: ${{ runner.os }}-${{ hashFiles('debian-db.zip') }}
 
   generate-packagist-versions:
     runs-on: ubuntu-latest
@@ -102,7 +115,7 @@ jobs:
   test-semantic:
     runs-on: ubuntu-latest
     needs:
-#      - generate-debian-versions
+      - generate-debian-versions
       - generate-packagist-versions
       - generate-pypi-versions
       - generate-rubygems-versions

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -28,6 +28,7 @@ jobs:
           python-version: '3.10'
       - run: dpkg --version
       - run: python3 generators/generate-debian-versions.py
+      - run: git status
       - run: stat debian-db.zip
       - uses: actions/upload-artifact@v3
         with:
@@ -50,6 +51,7 @@ jobs:
           php-version: '8.2'
           extensions: zip
       - run: php generators/generate-packagist-versions.php
+      - run: git status
       - uses: actions/upload-artifact@v3
         with:
           name: generated-versions
@@ -67,6 +69,7 @@ jobs:
       - name: setup dependencies
         run: pip install packaging==21.3
       - run: python3 generators/generate-pypi-versions.py
+      - run: git status
       - uses: actions/upload-artifact@v3
         with:
           name: generated-versions
@@ -84,6 +87,7 @@ jobs:
       - name: setup dependencies
         run: gem install rubyzip
       - run: ruby generators/generate-rubygems-versions.rb
+      - run: git status
       - uses: actions/upload-artifact@v3
         with:
           name: generated-versions
@@ -107,6 +111,7 @@ jobs:
           curl https://repo1.maven.org/maven2/org/apache/maven/maven-artifact/3.8.5/maven-artifact-3.8.5.jar \
             -o generators/lib/maven-artifact-3.8.5.jar
       - run: java -cp 'generators/lib/*' generators/GenerateMavenVersions.java
+      - run: git status
       - uses: actions/upload-artifact@v3
         with:
           name: generated-versions

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,0 +1,100 @@
+name: Semantic
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - generator-workflows
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  generate-debian-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: dpkg --version
+      - run: python3 generators/generate-debian-versions.py
+      - uses: actions/upload-artifact@v3
+        with:
+          name: generated-versions
+          path: pkg/semantic/fixtures/debian-versions-generated.txt
+
+  generate-packagist-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: zip
+      - run: php generators/generate-packagist-versions.php
+      - uses: actions/upload-artifact@v3
+        with:
+          name: generated-versions
+          path: pkg/semantic/fixtures/packagist-versions-generated.txt
+
+  generate-pypi-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: setup dependencies
+        run: pip install packaging==21.3
+      - run: python3 generators/generate-pypi-versions.py
+      - uses: actions/upload-artifact@v3
+        with:
+          name: generated-versions
+          path: pkg/semantic/fixtures/pypi-versions-generated.txt
+
+  generate-rubygems-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+      - name: setup dependencies
+        run: gem install rubyzip
+      - run: ruby generators/generate-rubygems-versions.rb
+      - uses: actions/upload-artifact@v3
+        with:
+          name: generated-versions
+          path: pkg/semantic/fixtures/rubygems-versions-generated.txt
+
+  generate-maven-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: oracle
+      - name: setup dependencies
+        run: |
+          mkdir -p generators/lib
+          curl https://repo1.maven.org/maven2/org/json/json/20220924/json-20220924.jar \
+            -o generators/lib/json-20220924.jar
+          curl https://repo1.maven.org/maven2/org/apache/maven/maven-artifact/3.8.5/maven-artifact-3.8.5.jar \
+            -o generators/lib/maven-artifact-3.8.5.jar
+      - run: java -cp 'generators/lib/*' generators/GenerateMavenVersions.java
+      - uses: actions/upload-artifact@v3
+        with:
+          name: generated-versions
+          path: pkg/semantic/fixtures/maven-versions-generated.txt

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -14,9 +14,9 @@ on:
           - all
           - failures
           - successes
-  push:
-    branches:
-      - generator-workflows
+  pull_request:
+    paths:
+      - 'generators/**'
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -98,3 +98,28 @@ jobs:
         with:
           name: generated-versions
           path: pkg/semantic/fixtures/maven-versions-generated.txt
+
+  test-semantic:
+    runs-on: ubuntu-latest
+    needs:
+#      - generate-debian-versions
+      - generate-packagist-versions
+      - generate-pypi-versions
+      - generate-rubygems-versions
+      - generate-maven-versions
+    if: always()
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: .go-version
+          cache: true
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: generated-versions
+          path: pkg/semantic/fixtures/
+      - run: git status
+      - run: make test

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -4,12 +4,25 @@ on:
   schedule:
     - cron: '0 0 * * SUN'
   workflow_dispatch:
+    inputs:
+      filterResults:
+        description: 'What comparator results the generators should print'
+        required: false
+        default: 'failures'
+        type: choice
+        options:
+          - all
+          - failures
+          - successes
   push:
     branches:
       - generator-workflows
 
 permissions:
   contents: read # to fetch code (actions/checkout)
+
+env:
+  VERSION_GENERATOR_PRINT: ${{ inputs.filterResults }}
 
 jobs:
   generate-debian-versions:

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,6 +1,8 @@
 name: Semantic
 
 on:
+  schedule:
+    - cron: '0 0 * * SUN'
   workflow_dispatch:
   push:
     branches:


### PR DESCRIPTION
Most of this should be understandable from reading the workflow itself, but a general overview is that this workflow runs each `semantic` fixture generator, collecting their generated fixture file as an artifact (`generated-versions.zip`, which is appended to by each job), and then that artifact is used in a run of the whole test suite to ensure `semantic` passes (which happens regardless of if any of the generators failed or not)

A bonus byproduct of this is that the artifact can be downloaded so that the contents can be easily committed on occasion without needing to have all the different languages setup locally; I've also configured the workflow to run every Sunday, whenever a generator is changed in a PR (as an easy way to double check that they work after the change), and via manually with `workflow_dispatch`.