### PR TITLE
fix: handle line continuations in `requirements.txt` files

### DIFF
--- a/pkg/lockfile/fixtures/pip/line-continuation.txt
+++ b/pkg/lockfile/fixtures/pip/line-continuation.txt
@@ -1,0 +1,17 @@
+# unescaped
+foo==\
+\
+ \
+  \
+1.2.3
+
+# escaped, a literal backslash for some reason
+bar == 4.5\\
+.6
+
+# comments are stripped only after line continuations are processed
+baz == 7.8.9 # \
+baz == 1.2.3
+
+# continue to end
+qux == 10.11.12\

--- a/pkg/lockfile/parse-requirements-txt_test.go
+++ b/pkg/lockfile/parse-requirements-txt_test.go
@@ -525,3 +525,40 @@ func TestParseRequirementsTxt_CyclicRComplex(t *testing.T) {
 		},
 	})
 }
+
+func TestParseRequirementsTxt_LineContinuation(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/line-continuation.txt")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "foo",
+			Version:   "1.2.3",
+			Ecosystem: lockfile.PipEcosystem,
+			CompareAs: lockfile.PipEcosystem,
+		},
+		{
+			Name:      "bar",
+			Version:   "4.5\\\\",
+			Ecosystem: lockfile.PipEcosystem,
+			CompareAs: lockfile.PipEcosystem,
+		},
+		{
+			Name:      "baz",
+			Version:   "7.8.9",
+			Ecosystem: lockfile.PipEcosystem,
+			CompareAs: lockfile.PipEcosystem,
+		},
+		{
+			Name:      "qux",
+			Version:   "10.11.12",
+			Ecosystem: lockfile.PipEcosystem,
+			CompareAs: lockfile.PipEcosystem,
+		},
+	})
+}


### PR DESCRIPTION
Originally implemented by @robotdana - have updated for Go v1.17