### PR TITLE
refactor: remove unneeded index check in favor of just always splitting

### DIFF
--- a/pkg/lockfile/parse-pnpm-lock.go
+++ b/pkg/lockfile/parse-pnpm-lock.go
@@ -96,11 +96,9 @@ func extractPnpmPackageNameAndVersion(dependencyPath string) (string, string) {
 		return "", ""
 	}
 
-	underscoreIndex := strings.Index(version, "_")
-
-	if underscoreIndex != -1 {
-		version = strings.Split(version, "_")[0]
-	}
+	// peer dependencies in v5 lockfiles are attached to the end of the version
+	// with an "_", so we always want the first element if an "_" is present
+	version = strings.Split(version, "_")[0]
 
 	return name, version
 }


### PR DESCRIPTION
I realised first that `strings.Contains` could be used instead of `strings.Index` but then realised we can just always do the `strings.Split` (which'll later get replaced with a `strings.Cut` after go 1.19) 🤷 