### PR TITLE
fix: use the first version when a dependency is listed multiple times in `pom.xml` files

### DIFF
--- a/pkg/lockfile/fixtures/maven/with-dependency-management-and-duplicates.xml
+++ b/pkg/lockfile/fixtures/maven/with-dependency-management-and-duplicates.xml
@@ -1,0 +1,35 @@
+<project>
+  <properties>
+    <mavenVersion>3.0</mavenVersion>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.13.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.13.0</version>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.13.4</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.13.4.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/pkg/lockfile/fixtures/maven/with-duplicate-packages.xml
+++ b/pkg/lockfile/fixtures/maven/with-duplicate-packages.xml
@@ -1,0 +1,25 @@
+<project>
+  <properties>
+    <mavenVersion>3.0</mavenVersion>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.13.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.13.4</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.13.4.1</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -64,6 +64,28 @@ type MavenLockFile struct {
 	ManagedDependencies []MavenLockDependency `xml:"dependencyManagement>dependencies>dependency"`
 }
 
+func (mlf *MavenLockFile) collectPackages(dependencies []MavenLockDependency) map[string]PackageDetails {
+	details := map[string]PackageDetails{}
+
+	for _, lockPackage := range dependencies {
+		finalName := lockPackage.GroupID + ":" + lockPackage.ArtifactID
+
+		// the first declaration of a dependency at a specific depth wins
+		if _, ok := details[finalName]; ok {
+			continue
+		}
+
+		details[finalName] = PackageDetails{
+			Name:      finalName,
+			Version:   lockPackage.ResolveVersion(*mlf),
+			Ecosystem: MavenEcosystem,
+			CompareAs: MavenEcosystem,
+		}
+	}
+
+	return details
+}
+
 const MavenEcosystem Ecosystem = "Maven"
 
 type MavenLockProperties struct {
@@ -113,29 +135,11 @@ func ParseMavenLock(pathToLockfile string) ([]PackageDetails, error) {
 		return []PackageDetails{}, fmt.Errorf("could not parse %s: %w", pathToLockfile, err)
 	}
 
-	details := map[string]PackageDetails{}
-
-	for _, lockPackage := range parsedLockfile.Dependencies {
-		finalName := lockPackage.GroupID + ":" + lockPackage.ArtifactID
-
-		details[finalName] = PackageDetails{
-			Name:      finalName,
-			Version:   lockPackage.ResolveVersion(*parsedLockfile),
-			Ecosystem: MavenEcosystem,
-			CompareAs: MavenEcosystem,
-		}
-	}
+	details := parsedLockfile.collectPackages(parsedLockfile.Dependencies)
 
 	// managed dependencies take precedent over standard dependencies
-	for _, lockPackage := range parsedLockfile.ManagedDependencies {
-		finalName := lockPackage.GroupID + ":" + lockPackage.ArtifactID
-
-		details[finalName] = PackageDetails{
-			Name:      finalName,
-			Version:   lockPackage.ResolveVersion(*parsedLockfile),
-			Ecosystem: MavenEcosystem,
-			CompareAs: MavenEcosystem,
-		}
+	for k, detail := range parsedLockfile.collectPackages(parsedLockfile.ManagedDependencies) {
+		details[k] = detail
 	}
 
 	return pkgDetailsMapToSlice(details), nil

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -89,6 +89,31 @@ func TestParseMavenLock_TwoPackages(t *testing.T) {
 	})
 }
 
+func TestParseMavenLock_WithDuplicatePackages(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseMavenLock("fixtures/maven/with-duplicate-packages.xml")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "com.fasterxml.jackson.core:jackson-annotations",
+			Version:   "2.13.3",
+			Ecosystem: lockfile.MavenEcosystem,
+			CompareAs: lockfile.MavenEcosystem,
+		},
+		{
+			Name:      "com.fasterxml.jackson.core:jackson-databind",
+			Version:   "2.13.4",
+			Ecosystem: lockfile.MavenEcosystem,
+			CompareAs: lockfile.MavenEcosystem,
+		},
+	})
+}
+
 func TestParseMavenLock_WithDependencyManagement(t *testing.T) {
 	t.Parallel()
 
@@ -114,6 +139,31 @@ func TestParseMavenLock_WithDependencyManagement(t *testing.T) {
 		{
 			Name:      "com.google.code.findbugs:jsr305",
 			Version:   "3.0.2",
+			Ecosystem: lockfile.MavenEcosystem,
+			CompareAs: lockfile.MavenEcosystem,
+		},
+	})
+}
+
+func TestParseMavenLock_WithDependencyManagementAndDuplicates(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseMavenLock("fixtures/maven/with-dependency-management-and-duplicates.xml")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "com.fasterxml.jackson.core:jackson-annotations",
+			Version:   "2.13.3",
+			Ecosystem: lockfile.MavenEcosystem,
+			CompareAs: lockfile.MavenEcosystem,
+		},
+		{
+			Name:      "com.fasterxml.jackson.core:jackson-databind",
+			Version:   "2.13.4",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
 		},


### PR DESCRIPTION
Per https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Transitive_Dependencies

> Note that if two dependency versions are at the same depth in the dependency tree, the first declaration wins.

It doesn't seem to explicitly mention what happens when there are duplicate packages for dependency management so I've assumed it follows the same behaviour.