### PR TITLE
ci: regenerate e2e fixtures when running scheduled semantic tests

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -142,11 +142,9 @@ jobs:
         with:
           go-version-file: .go-version
           cache: true
-      - run: make build
-      - run: go install
-
       - uses: actions/setup-node@v3
-      - run: generators/generate-e2e-fixtures.js
+
+      - run: make regenerate-e2e-fixtures
       - uses: actions/upload-artifact@v3
         with:
           name: e2e-fixtures

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -143,6 +143,7 @@ jobs:
           go-version-file: .go-version
           cache: true
       - run: make build
+      - run: go install
 
       - uses: actions/setup-node@v3
       - run: generators/generate-e2e-fixtures.js

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -132,6 +132,25 @@ jobs:
           name: generated-versions
           path: pkg/semantic/fixtures/maven-versions-generated.txt
 
+  generate-e2e-fixtures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: .go-version
+          cache: true
+      - run: make build
+
+      - uses: actions/setup-node@v3
+      - run: generators/generate-e2e-fixtures.js
+      - uses: actions/upload-artifact@v3
+        with:
+          name: e2e-fixtures
+          path: fixtures/locks-e2e/
+
   test-semantic:
     runs-on: ubuntu-latest
     needs:
@@ -140,6 +159,7 @@ jobs:
       - generate-pypi-versions
       - generate-rubygems-versions
       - generate-maven-versions
+      - generate-e2e-fixtures
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -150,6 +170,10 @@ jobs:
           go-version-file: .go-version
           cache: true
 
+      - uses: actions/download-artifact@v3
+        with:
+          name: e2e-fixtures
+          path: fixtures/locks-e2e/
       - uses: actions/download-artifact@v3
         with:
           name: generated-versions


### PR DESCRIPTION
I had opened the fixtures might have stabilized over time, but they have not - I'll be considering what to do long term, but for now this is an easy way to ensure the weekly `semantic` tests don't constantly fall over.