### PR TITLE
docs: provide jq command that does not group by ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ You can use `jq` to generate a list of OSV ids if you want to ignore all current
 known vulnerabilities found by the detector:
 
 ```shell
-osv-detector --json . | jq -r  '.results[].packages | map("- " + .vulnerabilities[].id) | unique | sort | .[]'
+osv-detector --json . | jq -r  '[.results[].packages | map("- " + .vulnerabilities[].id)] | flatten | unique | sort | .[]'
 ```
 
 #### Extra Databases


### PR DESCRIPTION
The current command only ends up sorting within an ecosystem - it's better to just sort advisories by their id only as an advisory can belong to multiple ecosystems (and that applies to any future features like automatically generating an ignore list)