### PR TITLE
refactor: update YAML library to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fatih/color v1.16.0
 	github.com/google/go-cmp v0.6.0
 	golang.org/x/mod v0.14.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -17,5 +17,5 @@ golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
 golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/configer/load.go
+++ b/internal/configer/load.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/g-rath/osv-detector/internal/reporter"
 	"github.com/g-rath/osv-detector/pkg/database"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type rawDatabaseConfig struct {
@@ -21,7 +21,7 @@ type rawDatabaseConfig struct {
 }
 
 type rawConfig struct {
-	FilePath  string
+	FilePath  string              `yaml:"-"`
 	Ignore    []string            `yaml:"ignore"`
 	Databases []rawDatabaseConfig `yaml:"extra-databases"`
 }

--- a/pkg/lockfile/parse-pnpm-lock.go
+++ b/pkg/lockfile/parse-pnpm-lock.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/g-rath/osv-detector/internal/cachedregexp"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type PnpmLockPackageResolution struct {
@@ -33,11 +33,11 @@ type pnpmLockfileV6 struct {
 	Packages map[string]PnpmLockPackage `yaml:"packages,omitempty"`
 }
 
-func (l *PnpmLockfile) UnmarshalYAML(unmarshal func(any) error) error {
+func (l *PnpmLockfile) UnmarshalYAML(value *yaml.Node) error {
 	var lockfileV6 pnpmLockfileV6
 
-	if err := unmarshal(&lockfileV6); err != nil {
-		return err
+	if err := value.Decode(&lockfileV6); err != nil {
+		return fmt.Errorf("%w", err)
 	}
 
 	parsedVersion, err := strconv.ParseFloat(lockfileV6.Version, 64)

--- a/pkg/lockfile/parse-pubspec-lock.go
+++ b/pkg/lockfile/parse-pubspec-lock.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type PubspecLockDescription struct {
@@ -14,9 +14,7 @@ type PubspecLockDescription struct {
 	Ref  string `yaml:"resolved-ref"`
 }
 
-var _ yaml.Unmarshaler = &PubspecLockDescription{}
-
-func (pld *PubspecLockDescription) UnmarshalYAML(unmarshal func(any) error) error {
+func (pld *PubspecLockDescription) UnmarshalYAML(value *yaml.Node) error {
 	var m struct {
 		Name string `yaml:"name"`
 		URL  string `yaml:"url"`
@@ -24,7 +22,7 @@ func (pld *PubspecLockDescription) UnmarshalYAML(unmarshal func(any) error) erro
 		Ref  string `yaml:"resolved-ref"`
 	}
 
-	err := unmarshal(&m)
+	err := value.Decode(&m)
 
 	if err == nil {
 		pld.Name = m.Name
@@ -37,10 +35,10 @@ func (pld *PubspecLockDescription) UnmarshalYAML(unmarshal func(any) error) erro
 
 	var str *string
 
-	err = unmarshal(&str)
+	err = value.Decode(&str)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("%w", err)
 	}
 
 	pld.Path = *str


### PR DESCRIPTION
This upgrades us to use the latest v3 version of the YAML library along with updating our unmarshal functions to use the new interface.

While this annoyingly adds ~20kb to the binary, it gives us access to more stuff like information about comments and line numbers when unmarshalling and the ability to write indented output (which will be used for #248) - ultimately, we might as well just get the upgrade over with.