### PR TITLE
chore: ensure that `package` exists in `affected` property in generators

### DIFF
--- a/generators/GenerateMavenVersions.java
+++ b/generators/GenerateMavenVersions.java
@@ -94,7 +94,7 @@ public class GenerateMavenVersions {
     osvs.forEach(osv -> osv.getJSONArray("affected").forEach(aff -> {
       JSONObject affected = (JSONObject) aff;
 
-      if(affected.getJSONObject("package").getString("ecosystem").equals("Maven")) {
+      if(!affected.has("package") || affected.getJSONObject("package").getString("ecosystem").equals("Maven")) {
         return;
       }
 

--- a/generators/generate-cran-versions.R
+++ b/generators/generate-cran-versions.R
@@ -24,7 +24,7 @@ extract_packages_with_versions <- function(osvs) {
 
   for (osv in osvs) {
     for (affected in osv$affected) {
-      if (affected$package$ecosystem != "CRAN") {
+      if (is.null(affected["package"]) || affected$package$ecosystem != "CRAN") {
         next
       }
 

--- a/generators/generate-debian-versions.py
+++ b/generators/generate-debian-versions.py
@@ -47,7 +47,7 @@ def extract_packages_with_versions(osvs):
 
   for osv in osvs:
     for affected in osv['affected']:
-      if not affected['package']['ecosystem'].startswith('Debian'):
+      if 'package' not in affected or not affected['package']['ecosystem'].startswith('Debian'):
         continue
 
       package = affected['package']['name']

--- a/generators/generate-packagist-versions.php
+++ b/generators/generate-packagist-versions.php
@@ -79,7 +79,7 @@ function fetchPackageVersions(): array
 
   foreach ($osvs as $osv) {
     foreach ($osv['affected'] as $affected) {
-      if ($affected['package']['ecosystem'] !== 'Packagist') {
+      if (!isset($affected['package']) || $affected['package']['ecosystem'] !== 'Packagist') {
         continue;
       }
 

--- a/generators/generate-pypi-versions.py
+++ b/generators/generate-pypi-versions.py
@@ -40,7 +40,7 @@ def extract_packages_with_versions(osvs):
 
   for osv in osvs:
     for affected in osv['affected']:
-      if affected['package']['ecosystem'] != 'PyPI':
+      if 'package' not in affected or affected['package']['ecosystem'] != 'PyPI':
         continue
 
       package = affected['package']['name']

--- a/generators/generate-rubygems-versions.rb
+++ b/generators/generate-rubygems-versions.rb
@@ -38,7 +38,7 @@ def extract_packages_with_versions(osvs)
 
   osvs.each do |osv|
     osv["affected"].each do |affected|
-      next unless affected["package"]["ecosystem"] == "RubyGems"
+      next unless affected.dig("package", "ecosystem") == "RubyGems"
 
       package = affected["package"]["name"]
 


### PR DESCRIPTION
This has always been allowed by the spec but now there's at least one real-world advisory in the Debian database like this which causes it to error.