### PR TITLE
ci: update `goreleaser/goreleaser-action` to v6 and `goreleaser` to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,9 +119,9 @@ jobs:
           cache: true
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 before:
@@ -38,4 +40,4 @@ checksum:
 release:
   draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
Per https://goreleaser.com/blog/goreleaser-v2 and https://goreleaser.com/deprecations