### PR TITLE
refactor: update `golangci-lint` to v1.59

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
-          version: v1.58
+          version: v1.59
   go-fmt:
     permissions:
       contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
-          version: v1.56
+          version: v1.57
   go-fmt:
     permissions:
       contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
-          version: v1.55
+          version: v1.56
   go-fmt:
     permissions:
       contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
-          version: v1.57
+          version: v1.58
   go-fmt:
     permissions:
       contents: read # to fetch code (actions/checkout)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,6 +22,7 @@ linters:
     - wsl              # disagree with, for now
     - ireturn          # disagree with, sort of
     - nonamedreturns   # they have their uses
+    - perfsprint       # enable in dedicated PR
   presets:
     - bugs
     - comment

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,7 +18,7 @@ linters:
     - lll              # line length is hard
     - godox            # to-do comments are fine
     - godot            # comments are fine without full stops
-    - gomnd            # not every number is magic
+    - mnd              # not every number is magic
     - wsl              # disagree with, for now
     - ireturn          # disagree with, sort of
     - nonamedreturns   # they have their uses

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,13 +8,8 @@ linters:
   disable:
     - tagliatelle      # we're parsing data from external sources
     - varnamelen       # maybe later
-    - exhaustivestruct # overkill
     - exhaustruct      # overkill
     - forcetypeassert  # too hard
-    - interfacer       # deprecated
-    - golint           # deprecated
-    - scopelint        # deprecated
-    - maligned         # deprecated
     - lll              # line length is hard
     - godox            # to-do comments are fine
     - godot            # comments are fine without full stops

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test-with-coverage:
 lint:	lint-with-golangci-lint lint-with-go-fmt
 
 lint-with-golangci-lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2 run ./... --max-same-issues 0
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.2 run ./... --max-same-issues 0
 
 lint-with-go-fmt:
 	gofmt -s -d */**.go

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test-with-coverage:
 lint:	lint-with-golangci-lint lint-with-go-fmt
 
 lint-with-golangci-lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2 run ./... --max-same-issues 0
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2 run ./... --max-same-issues 0
 
 lint-with-go-fmt:
 	gofmt -s -d */**.go

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test-with-coverage:
 lint:	lint-with-golangci-lint lint-with-go-fmt
 
 lint-with-golangci-lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2 run ./... --max-same-issues 0
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2 run ./... --max-same-issues 0
 
 lint-with-go-fmt:
 	gofmt -s -d */**.go

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test-with-coverage:
 lint:	lint-with-golangci-lint lint-with-go-fmt
 
 lint-with-golangci-lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.2 run ./... --max-same-issues 0
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1 run ./... --max-same-issues 0
 
 lint-with-go-fmt:
 	gofmt -s -d */**.go

--- a/internal/reporter/reporter_test.go
+++ b/internal/reporter/reporter_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/g-rath/osv-detector/pkg/database"
 )
 
+var errOhNoes = fmt.Errorf("oh noes")
+
 type TestResult struct {
 	Value                string `json:"value"`
 	ErrorWhenMarshalling bool   `json:"-"`
@@ -24,7 +26,7 @@ func (r TestResult) MarshalJSON() ([]byte, error) {
 	type rawTestResult TestResult
 
 	if r.ErrorWhenMarshalling {
-		return nil, fmt.Errorf("oh noes, an error")
+		return nil, errOhNoes
 	}
 
 	out, err := json.Marshal((rawTestResult)(r))
@@ -205,7 +207,7 @@ func TestReporter_PrintDatabaseLoadErr(t *testing.T) {
 			name: "",
 			args: args{
 				outputAsJSON: false,
-				err:          fmt.Errorf("oh noes"),
+				err:          errOhNoes,
 			},
 			wantedStdout: "",
 			wantedStderr: " failed: oh noes\n",
@@ -214,7 +216,7 @@ func TestReporter_PrintDatabaseLoadErr(t *testing.T) {
 			name: "",
 			args: args{
 				outputAsJSON: true,
-				err:          fmt.Errorf("oh noes"),
+				err:          errOhNoes,
 			},
 			wantedStdout: "",
 			wantedStderr: " failed: oh noes\n",

--- a/main_test.go
+++ b/main_test.go
@@ -1381,7 +1381,7 @@ func TestRun_Ignores(t *testing.T) {
 func setupConfigForUpdating(t *testing.T, path string, initial string, updated string) func() {
 	t.Helper()
 
-	err := os.WriteFile(path, []byte(initial), os.ModePerm)
+	err := os.WriteFile(path, []byte(initial), 0600)
 
 	if err != nil {
 		t.Fatalf("could not create test file: %v", err)

--- a/pkg/database/api-check.go
+++ b/pkg/database/api-check.go
@@ -183,10 +183,10 @@ func (db APIDB) Check(pkgs []internal.PackageDetails) ([]Vulnerabilities, error)
 			return nil, err
 		}
 
-		for _, withIDS := range results {
-			vulns := make(Vulnerabilities, 0, len(withIDS))
+		for _, withIDs := range results {
+			vulns := make(Vulnerabilities, 0, len(withIDs))
 
-			for _, withID := range withIDS {
+			for _, withID := range withIDs {
 				vulns = append(vulns, OSV{ID: withID.ID})
 			}
 

--- a/pkg/database/api-check_test.go
+++ b/pkg/database/api-check_test.go
@@ -90,7 +90,7 @@ func expectVulnerability(t *testing.T, vuln database.OSV, id string, summary str
 func TestAPIDB_Check_NoPackages(t *testing.T) {
 	t.Parallel()
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		t.Errorf("an API request was made even though there are no packages to check")
 	}))
 	t.Cleanup(ts.Close)
@@ -273,7 +273,7 @@ func TestAPIDB_Check_FetchSuccessful(t *testing.T) {
 		_, _ = w.Write(jsonData)
 	})
 
-	mux.HandleFunc("/vulns/GHSA-1234", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/vulns/GHSA-1234", func(w http.ResponseWriter, _ *http.Request) {
 		jsonData, err := json.Marshal(database.OSV{ID: "GHSA-1234", Summary: "my vulnerability"})
 
 		if err != nil {
@@ -330,12 +330,12 @@ func TestAPIDB_Check_FetchFails(t *testing.T) {
 	})
 
 	// this response is not a 200 OK
-	mux.HandleFunc("/vulns/GHSA-1234", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/vulns/GHSA-1234", func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "oh noes!", http.StatusForbidden)
 	})
 
 	// this response is not valid json
-	mux.HandleFunc("/vulns/GHSA-5678", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/vulns/GHSA-5678", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("<html></html>"))
 	})
 
@@ -386,7 +386,7 @@ func TestAPIDB_Check_FetchMixed(t *testing.T) {
 		_, _ = w.Write(jsonData)
 	})
 
-	mux.HandleFunc("/vulns/GHSA-1234", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/vulns/GHSA-1234", func(w http.ResponseWriter, _ *http.Request) {
 		jsonData, err := json.Marshal(database.OSV{ID: "GHSA-1234", Summary: "my vulnerability"})
 
 		if err != nil {

--- a/pkg/database/zip_test.go
+++ b/pkg/database/zip_test.go
@@ -136,7 +136,7 @@ func zipOSVs(t *testing.T, osvs map[string]database.OSV) []byte {
 func TestNewZippedDB_Offline_WithoutCache(t *testing.T) {
 	t.Parallel()
 
-	ts := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
+	ts := createZipServer(t, func(_ http.ResponseWriter, _ *http.Request) {
 		t.Errorf("a server request was made when running offline")
 	})
 
@@ -159,7 +159,7 @@ func TestNewZippedDB_Offline_WithCache(t *testing.T) {
 		withDefaultAffected("GHSA-5"),
 	}
 
-	ts := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
+	ts := createZipServer(t, func(_ http.ResponseWriter, _ *http.Request) {
 		t.Errorf("a server request was made when running offline")
 	})
 
@@ -192,7 +192,7 @@ func TestNewZippedDB_Offline_WithCache(t *testing.T) {
 func TestNewZippedDB_BadZip(t *testing.T) {
 	t.Parallel()
 
-	ts := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
+	ts := createZipServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("this is not a zip"))
 	})
 
@@ -224,7 +224,7 @@ func TestNewZippedDB_Online_WithoutCache(t *testing.T) {
 		withDefaultAffected("GHSA-5"),
 	}
 
-	ts := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
+	ts := createZipServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write(zipOSVs(t, map[string]database.OSV{
 			"GHSA-1.json": withDefaultAffected("GHSA-1"),
 			"GHSA-2.json": withDefaultAffected("GHSA-2"),
@@ -246,7 +246,7 @@ func TestNewZippedDB_Online_WithoutCache(t *testing.T) {
 func TestNewZippedDB_Online_WithoutCache_NotFound(t *testing.T) {
 	t.Parallel()
 
-	ts := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
+	ts := createZipServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write(zipOSVs(t, map[string]database.OSV{}))
 	})
@@ -362,7 +362,7 @@ func TestNewZippedDB_Online_WithBadCache(t *testing.T) {
 		withDefaultAffected("GHSA-3"),
 	}
 
-	ts := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
+	ts := createZipServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write(zipOSVs(t, map[string]database.OSV{
 			"GHSA-1.json": withDefaultAffected("GHSA-1"),
 			"GHSA-2.json": withDefaultAffected("GHSA-2"),
@@ -386,7 +386,7 @@ func TestNewZippedDB_FileChecks(t *testing.T) {
 
 	osvs := []database.OSV{withDefaultAffected("GHSA-1234"), withDefaultAffected("GHSA-4321")}
 
-	ts := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
+	ts := createZipServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write(zipOSVs(t, map[string]database.OSV{
 			"file.json": withDefaultAffected("GHSA-1234"),
 			// only files with .json suffix should be loaded
@@ -410,7 +410,7 @@ func TestNewZippedDB_WorkingDirectory(t *testing.T) {
 
 	osvs := []database.OSV{withDefaultAffected("GHSA-1234"), withDefaultAffected("GHSA-5678")}
 
-	ts := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
+	ts := createZipServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write(zipOSVs(t, map[string]database.OSV{
 			"reviewed/file.json":        withDefaultAffected("GHSA-1234"),
 			"reviewed/nested/file.json": withDefaultAffected("GHSA-5678"),


### PR DESCRIPTION
We can't go any higher right now because the next version required Go v1.22, and results in some errors