### PR TITLE
refactor: enable `perfsprint` to ensure performant string printing

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,7 +17,6 @@ linters:
     - wsl              # disagree with, for now
     - ireturn          # disagree with, sort of
     - nonamedreturns   # they have their uses
-    - perfsprint       # enable in dedicated PR
   presets:
     - bugs
     - comment

--- a/internal/reporter/reporter_test.go
+++ b/internal/reporter/reporter_test.go
@@ -3,6 +3,7 @@ package reporter_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -11,7 +12,7 @@ import (
 	"github.com/g-rath/osv-detector/pkg/database"
 )
 
-var errOhNoes = fmt.Errorf("oh noes")
+var errOhNoes = errors.New("oh noes")
 
 type TestResult struct {
 	Value                string `json:"value"`

--- a/main.go
+++ b/main.go
@@ -157,10 +157,7 @@ func uniqueDBConfigs(configs []*configer.Config) []database.Config {
 func describeDB(db database.DB) string {
 	switch tt := db.(type) {
 	case *database.APIDB:
-		return fmt.Sprintf(
-			"using batches of %s",
-			color.YellowString("%d", tt.BatchSize),
-		)
+		return "using batches of " + color.YellowString("%d", tt.BatchSize)
 	case *database.ZipDB:
 		count := tt.VulnerabilitiesCount
 

--- a/pkg/semantic/version-pypi.go
+++ b/pkg/semantic/version-pypi.go
@@ -94,7 +94,7 @@ func normalizePyPILegacyPart(part string) string {
 		return fmt.Sprintf("%08s", part)
 	}
 
-	return fmt.Sprintf("*%s", part)
+	return "*" + part
 }
 
 func parsePyPIVersionParts(str string) (parts []string) {
@@ -191,7 +191,7 @@ func (pv PyPIVersion) preIndex() int {
 		}
 	}
 
-	panic(fmt.Sprintf("unknown prefix %s", pv.pre.letter))
+	panic("unknown prefix " + pv.pre.letter)
 }
 
 // Checks if this PyPIVersion should apply a sort trick when comparing pre,


### PR DESCRIPTION
While I was initially going to label this as a `perf`ormance improvement, after seeing how few lines are being changed I'm just going to call it a `refactor`