### PR TITLE
refactor(semantic): simplify comparing of RubyGem version components

### DIFF
--- a/pkg/semantic/version-rubygems.go
+++ b/pkg/semantic/version-rubygems.go
@@ -1,7 +1,6 @@
 package semantic
 
 import (
-	"strconv"
 	"strings"
 )
 
@@ -73,11 +72,9 @@ func canonicalSegments(segs []string) (canSegs []string) {
 }
 
 func compareRubyGemsComponents(a, b []string) int {
-	max := maxInt(len(a), len(b))
+	numberOfComponents := maxInt(len(a), len(b))
 
-	var compare int
-
-	for i := 0; i < max; i++ {
+	for i := 0; i < numberOfComponents; i++ {
 		as := fetch(a, i, "0")
 		bs := fetch(b, i, "0")
 
@@ -86,42 +83,18 @@ func compareRubyGemsComponents(a, b []string) int {
 
 		switch {
 		case aIsNumber && bIsNumber:
-			compare = ai.Cmp(bi)
-		case !aIsNumber && !bIsNumber:
-			compare = strings.Compare(as, bs)
-		case aIsNumber:
-			compare = +1
-		default:
-			compare = -1
-		}
-
-		if compare != 0 {
-			if compare > 0 {
-				return 1
+			if diff := ai.Cmp(bi); diff != 0 {
+				return diff
 			}
-
+		case !aIsNumber && !bIsNumber:
+			if diff := strings.Compare(as, bs); diff != 0 {
+				return diff
+			}
+		case aIsNumber:
+			return +1
+		default:
 			return -1
 		}
-	}
-
-	if len(a) > len(b) {
-		next := a[len(b)]
-
-		if _, err := strconv.Atoi(next); err == nil {
-			return 1
-		}
-
-		return -1
-	}
-
-	if len(a) < len(b) {
-		next := b[len(a)]
-
-		if _, err := strconv.Atoi(next); err == nil {
-			return -1
-		}
-
-		return +1
 	}
 
 	return 0


### PR DESCRIPTION
I realised that I have overly complicated the act of returning the result of comparing components in this function, and that the last two conditions will never be true as we loop over the largest number of components 😅 