### PR TITLE
refactor(semantic): sort ecosystems by name

### DIFF
--- a/pkg/semantic/parse.go
+++ b/pkg/semantic/parse.go
@@ -21,30 +21,30 @@ func MustParse(str string, ecosystem internal.Ecosystem) Version {
 
 func Parse(str string, ecosystem internal.Ecosystem) (Version, error) {
 	switch ecosystem {
-	case "npm":
-		return parseSemverVersion(str), nil
+	case "CRAN":
+		return parseCRANVersion(str), nil
 	case "crates.io":
 		return parseSemverVersion(str), nil
 	case "Debian":
 		return parseDebianVersion(str), nil
-	case "RubyGems":
-		return parseRubyGemsVersion(str), nil
-	case "NuGet":
-		return parseNuGetVersion(str), nil
-	case "Packagist":
-		return parsePackagistVersion(str), nil
 	case "Go":
 		return parseSemverVersion(str), nil
 	case "Hex":
 		return parseSemverVersion(str), nil
 	case "Maven":
 		return parseMavenVersion(str), nil
-	case "PyPI":
-		return parsePyPIVersion(str), nil
+	case "npm":
+		return parseSemverVersion(str), nil
+	case "NuGet":
+		return parseNuGetVersion(str), nil
+	case "Packagist":
+		return parsePackagistVersion(str), nil
 	case "Pub":
 		return parseSemverVersion(str), nil
-	case "CRAN":
-		return parseCRANVersion(str), nil
+	case "PyPI":
+		return parsePyPIVersion(str), nil
+	case "RubyGems":
+		return parseRubyGemsVersion(str), nil
 	}
 
 	return nil, fmt.Errorf("%w %s", ErrUnsupportedEcosystem, ecosystem)


### PR DESCRIPTION
Having ecosystems sorted by their name makes it easier to review this section of code