### PR TITLE
refactor(semantic): remove unneeded logic in parsing semver-like versions

### DIFF
--- a/pkg/semantic/version-semver-like.go
+++ b/pkg/semantic/version-semver-like.go
@@ -38,10 +38,6 @@ func (v *SemverLikeVersion) fetchComponentsAndBuild(maxComponents int) (Componen
 func ParseSemverLikeVersion(line string, maxComponents int) SemverLikeVersion {
 	v := parseSemverLike(line)
 
-	if maxComponents == -1 {
-		return v
-	}
-
 	components, build := v.fetchComponentsAndBuild(maxComponents)
 
 	return SemverLikeVersion{
@@ -60,7 +56,6 @@ func parseSemverLike(line string) SemverLikeVersion {
 
 	currentCom := ""
 	foundBuild := false
-	emptyComponent := false
 
 	leadingV := strings.HasPrefix(line, "v")
 	line = strings.TrimPrefix(line, "v")
@@ -94,15 +89,11 @@ func parseSemverLike(line string) SemverLikeVersion {
 
 			components = append(components, v)
 			currentCom = ""
-
-			emptyComponent = false
 		}
 
 		// a component terminator means there might be another component
 		// afterwards, so don't start parsing the build string just yet
 		if c == '.' {
-			emptyComponent = true
-
 			continue
 		}
 
@@ -118,19 +109,6 @@ func parseSemverLike(line string) SemverLikeVersion {
 
 		components = append(components, v)
 		currentCom = ""
-		emptyComponent = false
-	}
-
-	// if we ended with an empty component section,
-	// prefix the build string with a '.'
-	if emptyComponent {
-		currentCom = "." + currentCom
-	}
-
-	// if we found no components, then the v wasn't actually leading
-	if len(components) == 0 && leadingV {
-		leadingV = false
-		currentCom = "v" + currentCom
 	}
 
 	return SemverLikeVersion{


### PR DESCRIPTION
While I'm a little reluctant to do this as I'm sure I included these for a reason, they're apparently not covered by any tests and the longer they remain the more likely someone might start actually depending on them.

I'm pretty sure the bulk of this was present as part of having `semantic` rebuild the parsed version for debugging when I was writing the implementation, but that's not actually a feature so we don't explicitly need to be doing it - this won't stop us from reintroducing the logic in future if we decide we want it