### PR TITLE
fix: process managed dependencies before standard dependencies when parsing `pom.xml`s

### DIFF
--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -115,7 +115,7 @@ func ParseMavenLock(pathToLockfile string) ([]PackageDetails, error) {
 
 	details := map[string]PackageDetails{}
 
-	for _, lockPackage := range parsedLockfile.Dependencies {
+	for _, lockPackage := range parsedLockfile.ManagedDependencies {
 		finalName := lockPackage.GroupID + ":" + lockPackage.ArtifactID
 
 		details[finalName] = PackageDetails{
@@ -126,8 +126,8 @@ func ParseMavenLock(pathToLockfile string) ([]PackageDetails, error) {
 		}
 	}
 
-	// managed dependencies take precedent over standard dependencies
-	for _, lockPackage := range parsedLockfile.ManagedDependencies {
+	// standard dependencies take precedent over managed dependencies
+	for _, lockPackage := range parsedLockfile.Dependencies {
 		finalName := lockPackage.GroupID + ":" + lockPackage.ArtifactID
 
 		details[finalName] = PackageDetails{

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -101,7 +101,7 @@ func TestParseMavenLock_WithDependencyManagement(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "io.netty:netty-all",
-			Version:   "4.1.42.Final",
+			Version:   "4.1.9",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
 		},


### PR DESCRIPTION
Turns out that actually managed dependencies should not take precedence over standard dependencies, as they're not real dependencies (at least when scanning only root `pom.xml`s)

Also see https://github.com/google/osv-scanner/pull/1000