### PR TITLE
chore: split `ldflags` over multiple items

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,8 +15,10 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      # prettier-ignore
-      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}}'
+      - '-s -w'
+      - '-X main.version={{.Version}}'
+      - '-X main.commit={{.Commit}}'
+      - '-X main.date={{.CommitDate}}'
     goos:
       - freebsd
       - windows


### PR DESCRIPTION
For some reason it never clicked to me that as this is an array, we can spread items across multiple lines/items