### PR TITLE
refactor: rename variables to avoid shadowing builtin functions

### DIFF
--- a/pkg/semantic/version-maven.go
+++ b/pkg/semantic/version-maven.go
@@ -137,12 +137,12 @@ func newMavenNullVersionToken(token mavenVersionToken) mavenVersionToken {
 }
 
 func (mv MavenVersion) lessThan(mw MavenVersion) bool {
-	max := maxInt(len(mv.tokens), len(mw.tokens))
+	numberOfTokens := maxInt(len(mv.tokens), len(mw.tokens))
 
 	var left mavenVersionToken
 	var right mavenVersionToken
 
-	for i := 0; i < max; i++ {
+	for i := 0; i < numberOfTokens; i++ {
 		// the shorter one padded with enough "null" values with matching prefix to
 		// have the same length as the longer one. Padded "null" values depend on
 		// the prefix of the other version: 0 for '.', "" for '-'

--- a/pkg/semantic/version-packagist.go
+++ b/pkg/semantic/version-packagist.go
@@ -53,11 +53,11 @@ func comparePackagistSpecialVersions(a, b string) int {
 }
 
 func comparePackagistComponents(a, b []string) int {
-	min := minInt(len(a), len(b))
+	minLength := minInt(len(a), len(b))
 
 	var compare int
 
-	for i := 0; i < min; i++ {
+	for i := 0; i < minLength; i++ {
 		ai, aIsNumber := convertToBigInt(a[i])
 		bi, bIsNumber := convertToBigInt(b[i])
 

--- a/pkg/semantic/version-pypi.go
+++ b/pkg/semantic/version-pypi.go
@@ -268,11 +268,11 @@ func (pv PyPIVersion) compareDev(pw PyPIVersion) int {
 
 // Compares the local segment of each version
 func (pv PyPIVersion) compareLocal(pw PyPIVersion) int {
-	min := minInt(len(pv.local), len(pw.local))
+	minVersionLength := minInt(len(pv.local), len(pw.local))
 
 	var compare int
 
-	for i := 0; i < min; i++ {
+	for i := 0; i < minVersionLength; i++ {
 		ai, aIsNumber := convertToBigInt(pv.local[i])
 		bi, bIsNumber := convertToBigInt(pw.local[i])
 

--- a/pkg/semantic/version-semver.go
+++ b/pkg/semantic/version-semver.go
@@ -39,11 +39,11 @@ func compareBuildComponents(a, b string) int {
 }
 
 func compareSemverBuildComponents(a, b []string) int {
-	min := minInt(len(a), len(b))
+	minComponentLength := minInt(len(a), len(b))
 
 	var compare int
 
-	for i := 0; i < min; i++ {
+	for i := 0; i < minComponentLength; i++ {
 		ai, aIsNumber := convertToBigInt(a[i])
 		bi, bIsNumber := convertToBigInt(b[i])
 


### PR DESCRIPTION
This will later be enforced by `revive`