### PR TITLE
chore: update `golangci-lint` to latest v1 version and simplify config

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
-          version: v1.60
+          version: v1.64
   go-fmt:
     permissions:
       contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
-          version: v1.60
+          version: v1.64
   go-fmt:
     permissions:
       contents: read # to fetch code (actions/checkout)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,15 +3,23 @@ output:
 linters:
   enable-all: true
   disable:
+    - cyclop
     - exhaustruct      # overkill
     - forcetypeassert  # too hard
+    - funlen
+    - gocognit
+    - gocyclo
     - godot            # comments are fine without full stops
     - godox            # to-do comments are fine
+    - maintidx
+    - gofumpt
     - ireturn          # disagree with, sort of
     - lll              # line length is hard
     - mnd              # not every number is magic
+    - nestif
     - nonamedreturns   # they have their uses
     - tagliatelle      # we're parsing data from external sources
+    - tenv             # Deprecated
     - varnamelen       # maybe later
     - wsl              # disagree with, for now
     - intrange

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,7 @@ output:
   sort-results: true
 linters:
   enable-all: true
+  # prettier-ignore
   disable:
     - cyclop
     - exhaustruct      # overkill

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,6 +44,8 @@ linters-settings:
               'Use github.com/g-rath/osv-detector/internal/cachedregexp instead'
 
 issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
   exclude-rules:
     - path: _test\.go
       linters:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,10 +1,7 @@
 output:
   sort-results: true
 linters:
-  enable:
-    - gofmt
-    - goimports
-  # prettier-ignore
+  enable-all: true
   disable:
     - exhaustruct      # overkill
     - forcetypeassert  # too hard
@@ -21,15 +18,6 @@ linters:
     - copyloopvar
     - predeclared
     - govet
-  presets:
-    - bugs
-    - comment
-    - error
-    - performance
-    - sql
-    - style
-    - test
-    - unused
 
 linters-settings:
   depguard:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,17 +6,17 @@ linters:
     - goimports
   # prettier-ignore
   disable:
-    - tagliatelle      # we're parsing data from external sources
-    - varnamelen       # maybe later
     - exhaustruct      # overkill
     - forcetypeassert  # too hard
-    - lll              # line length is hard
-    - godox            # to-do comments are fine
     - godot            # comments are fine without full stops
-    - mnd              # not every number is magic
-    - wsl              # disagree with, for now
+    - godox            # to-do comments are fine
     - ireturn          # disagree with, sort of
+    - lll              # line length is hard
+    - mnd              # not every number is magic
     - nonamedreturns   # they have their uses
+    - tagliatelle      # we're parsing data from external sources
+    - varnamelen       # maybe later
+    - wsl              # disagree with, for now
     - intrange
     - copyloopvar
     - predeclared

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test-with-coverage:
 lint:	lint-with-golangci-lint lint-with-go-fmt
 
 lint-with-golangci-lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0 run ./... --max-same-issues 0
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./... --max-same-issues 0
 
 lint-with-go-fmt:
 	gofmt -s -d */**.go

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test-with-coverage:
 lint:	lint-with-golangci-lint lint-with-go-fmt
 
 lint-with-golangci-lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./... --max-same-issues 0
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./...
 
 lint-with-go-fmt:
 	gofmt -s -d */**.go


### PR DESCRIPTION
This will make it easier to discover new linters and upgrade to v2