### PR TITLE
refactor: use `range` for looping over ints

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,7 +23,6 @@ linters:
     - tenv             # Deprecated
     - varnamelen       # maybe later
     - wsl              # disagree with, for now
-    - intrange
     - predeclared
     - govet
 

--- a/pkg/semantic/version-debian.go
+++ b/pkg/semantic/version-debian.go
@@ -91,7 +91,7 @@ func compareDebianVersions(a, b string) int {
 			apSplit := strings.Split(ap, "")
 			bpSplit := strings.Split(bp, "")
 
-			for i := 0; i < maxInt(len(ap), len(bp)); i++ {
+			for i := range maxInt(len(ap), len(bp)) {
 				aw := weighDebianChar(fetch(apSplit, i, ""))
 				bw := weighDebianChar(fetch(bpSplit, i, ""))
 

--- a/pkg/semantic/version-maven.go
+++ b/pkg/semantic/version-maven.go
@@ -108,7 +108,7 @@ func (mv MavenVersion) equal(mw MavenVersion) bool {
 		return false
 	}
 
-	for i := 0; i < len(mv.tokens); i++ {
+	for i := range len(mv.tokens) {
 		if !mv.tokens[i].equal(mw.tokens[i]) {
 			return false
 		}
@@ -142,7 +142,7 @@ func (mv MavenVersion) lessThan(mw MavenVersion) bool {
 	var left mavenVersionToken
 	var right mavenVersionToken
 
-	for i := 0; i < numberOfTokens; i++ {
+	for i := range numberOfTokens {
 		// the shorter one padded with enough "null" values with matching prefix to
 		// have the same length as the longer one. Padded "null" values depend on
 		// the prefix of the other version: 0 for '.', "" for '-'

--- a/pkg/semantic/version-packagist.go
+++ b/pkg/semantic/version-packagist.go
@@ -57,7 +57,7 @@ func comparePackagistComponents(a, b []string) int {
 
 	var compare int
 
-	for i := 0; i < minLength; i++ {
+	for i := range minLength {
 		ai, aIsNumber := convertToBigInt(a[i])
 		bi, bIsNumber := convertToBigInt(b[i])
 

--- a/pkg/semantic/version-pypi.go
+++ b/pkg/semantic/version-pypi.go
@@ -272,7 +272,7 @@ func (pv PyPIVersion) compareLocal(pw PyPIVersion) int {
 
 	var compare int
 
-	for i := 0; i < minVersionLength; i++ {
+	for i := range minVersionLength {
 		ai, aIsNumber := convertToBigInt(pv.local[i])
 		bi, bIsNumber := convertToBigInt(pw.local[i])
 

--- a/pkg/semantic/version-rubygems.go
+++ b/pkg/semantic/version-rubygems.go
@@ -74,7 +74,7 @@ func canonicalSegments(segs []string) (canSegs []string) {
 func compareRubyGemsComponents(a, b []string) int {
 	numberOfComponents := maxInt(len(a), len(b))
 
-	for i := 0; i < numberOfComponents; i++ {
+	for i := range numberOfComponents {
 		as := fetch(a, i, "0")
 		bs := fetch(b, i, "0")
 

--- a/pkg/semantic/version-semver.go
+++ b/pkg/semantic/version-semver.go
@@ -43,7 +43,7 @@ func compareSemverBuildComponents(a, b []string) int {
 
 	var compare int
 
-	for i := 0; i < minComponentLength; i++ {
+	for i := range minComponentLength {
 		ai, aIsNumber := convertToBigInt(a[i])
 		bi, bIsNumber := convertToBigInt(b[i])
 

--- a/pkg/semantic/version.go
+++ b/pkg/semantic/version.go
@@ -25,7 +25,7 @@ func (components *Components) Fetch(n int) *big.Int {
 func (components *Components) Cmp(b Components) int {
 	numberOfComponents := maxInt(len(*components), len(b))
 
-	for i := 0; i < numberOfComponents; i++ {
+	for i := range numberOfComponents {
 		diff := components.Fetch(i).Cmp(b.Fetch(i))
 
 		if diff != 0 {


### PR DESCRIPTION
Thank goodness for Go v1.22 😄