### PR TITLE
chore: enable `predeclared` and `govet` linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,8 +23,6 @@ linters:
     - tenv             # Deprecated
     - varnamelen       # maybe later
     - wsl              # disagree with, for now
-    - predeclared
-    - govet
 
 linters-settings:
   depguard:

--- a/pkg/database/api_test.go
+++ b/pkg/database/api_test.go
@@ -79,6 +79,9 @@ func TestNewAPIDB_Valid(t *testing.T) {
 
 	if db == nil {
 		t.Fatalf("NewAPIDB() db unexpectedly nil")
+
+		// this is required currently to make the staticcheck linter
+		return
 	}
 
 	if !reflect.DeepEqual(db.BaseURL, u) {


### PR DESCRIPTION
Neither of these have violations, though for some reason enabling `govet` makes `staticcheck` flag an area of code in a test that could be nil as apparently it doesn't understand that we're using `t.Fatal`?

Sticking a `return` makes it happy, so I'm doing that for now and will revisit when we're upgraded to v2 of the linter