### PR TITLE
test(semantic): address todo relating to `CRAN` ecosystem

### DIFF
--- a/pkg/semantic/parse_test.go
+++ b/pkg/semantic/parse_test.go
@@ -13,8 +13,7 @@ func TestParse(t *testing.T) {
 
 	ecosystems := lockfile.KnownEcosystems()
 
-	// todo: remove once CRAN is supported by lockfile
-	ecosystems = append(ecosystems, "CRAN", "Alpine", "Ubuntu")
+	ecosystems = append(ecosystems, "Alpine", "Debian", "Ubuntu")
 
 	for _, ecosystem := range ecosystems {
 		_, err := semantic.Parse("", ecosystem)
@@ -36,8 +35,7 @@ func TestMustParse(t *testing.T) {
 
 	ecosystems := lockfile.KnownEcosystems()
 
-	// todo: remove once CRAN is supported by lockfile
-	ecosystems = append(ecosystems, "CRAN", "Alpine", "Ubuntu")
+	ecosystems = append(ecosystems, "Alpine", "Debian", "Ubuntu")
 
 	for _, ecosystem := range ecosystems {
 		semantic.MustParse("", ecosystem)

--- a/pkg/semantic/parse_test.go
+++ b/pkg/semantic/parse_test.go
@@ -13,7 +13,7 @@ func TestParse(t *testing.T) {
 
 	ecosystems := lockfile.KnownEcosystems()
 
-	ecosystems = append(ecosystems, "Alpine", "Debian", "Ubuntu")
+	ecosystems = append(ecosystems, "Alpine", "Debian", "Ubuntu", "Red Hat")
 
 	for _, ecosystem := range ecosystems {
 		_, err := semantic.Parse("", ecosystem)
@@ -35,7 +35,7 @@ func TestMustParse(t *testing.T) {
 
 	ecosystems := lockfile.KnownEcosystems()
 
-	ecosystems = append(ecosystems, "Alpine", "Debian", "Ubuntu")
+	ecosystems = append(ecosystems, "Alpine", "Debian", "Ubuntu", "Red Hat")
 
 	for _, ecosystem := range ecosystems {
 		semantic.MustParse("", ecosystem)


### PR DESCRIPTION
We no longer need to add `CRAN` manually as it's supported by `lockfile`, but we should be adding `Debian` and `Red Hat` as they are not