### PR TITLE
feat: update to Go v1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/g-rath/osv-detector
 
-go 1.23.8
+go 1.24.6
 
 require (
 	github.com/BurntSushi/toml v1.5.0

--- a/internal/reporter/reporter_test.go
+++ b/internal/reporter/reporter_test.go
@@ -47,7 +47,7 @@ func TestReporter_PrintError(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	r := reporter.New(stdout, stderr, false)
 
-	r.PrintErrorf(msg)
+	r.PrintErrorf("%s", msg)
 
 	if gotStdout := stdout.String(); gotStdout != "" {
 		t.Errorf("Expected stdout to be empty, but got \"%s\"", gotStdout)
@@ -177,7 +177,7 @@ func TestReporter_PrintText(t *testing.T) {
 			stderr := &bytes.Buffer{}
 
 			r := reporter.New(stdout, stderr, tt.args.outputAsJSON)
-			r.PrintTextf(tt.args.msg)
+			r.PrintTextf("%s", tt.args.msg)
 
 			if gotStdout := stdout.String(); gotStdout != tt.wantedStdout {
 				t.Errorf("stdout got = %s, want %s", gotStdout, tt.wantedStdout)

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func (dbs OSVDatabases) check(r *reporter.Reporter, lockf lockfile.Lockfile, ign
 		results, err := db.Check(lockf.Packages)
 
 		if err != nil {
-			r.PrintErrorf(color.RedString(fmt.Sprintf(
+			r.PrintErrorf("%s", color.RedString(fmt.Sprintf(
 				"  an api error occurred while trying to check the packages listed in %s: %v\n",
 				lockf.FilePath,
 				err,
@@ -755,9 +755,9 @@ func writeUpdatedConfigs(r *reporter.Reporter, vulnsPerConfig map[string]map[str
 
 	for _, line := range lines {
 		if strings.HasPrefix(line, "Error updating") {
-			r.PrintErrorf(line)
+			r.PrintErrorf("%s", line)
 		} else {
-			r.PrintTextf(line)
+			r.PrintTextf("%s", line)
 		}
 	}
 }


### PR DESCRIPTION
This lets us use `osv-scalibr` - it has meant `govet` now complains when using formatting functions without a constant format string, which I've just addressed by adding such a string rather than adding two new dedicated functions for not-formatting