### PR TITLE
test: use `t.Fatalf` for unexpected errors

### DIFF
--- a/pkg/database/api-check_test.go
+++ b/pkg/database/api-check_test.go
@@ -104,7 +104,7 @@ func TestAPIDB_Check_NoPackages(t *testing.T) {
 	vulns, err := db.Check([]internal.PackageDetails{})
 
 	if err != nil {
-		t.Errorf("unexpected error \"%v\"", err)
+		t.Fatalf("unexpected error \"%v\"", err)
 	}
 
 	if len(vulns) > 0 {
@@ -297,7 +297,7 @@ func TestAPIDB_Check_FetchSuccessful(t *testing.T) {
 	})
 
 	if err != nil {
-		t.Errorf("unexpected error \"%v\"", err)
+		t.Fatalf("unexpected error \"%v\"", err)
 	}
 
 	if len(vulns) != 1 {
@@ -353,7 +353,7 @@ func TestAPIDB_Check_FetchFails(t *testing.T) {
 	})
 
 	if err != nil {
-		t.Errorf("unexpected error \"%v\"", err)
+		t.Fatalf("unexpected error \"%v\"", err)
 	}
 
 	if len(vulns) != 1 {
@@ -410,7 +410,7 @@ func TestAPIDB_Check_FetchMixed(t *testing.T) {
 	})
 
 	if err != nil {
-		t.Errorf("unexpected error \"%v\"", err)
+		t.Fatalf("unexpected error \"%v\"", err)
 	}
 
 	if len(vulns) != 1 {
@@ -452,7 +452,7 @@ func TestAPIDB_Check_WithCommit(t *testing.T) {
 	})
 
 	if err != nil {
-		t.Errorf("unexpected error \"%v\"", err)
+		t.Fatalf("unexpected error \"%v\"", err)
 	}
 
 	if len(vulns) != 1 {
@@ -524,7 +524,7 @@ func TestAPIDB_Check_Batches(t *testing.T) {
 	})
 
 	if err != nil {
-		t.Errorf("unexpected error \"%v\"", err)
+		t.Fatalf("unexpected error \"%v\"", err)
 	}
 
 	if requestCount != 2 {

--- a/pkg/database/api_test.go
+++ b/pkg/database/api_test.go
@@ -74,14 +74,11 @@ func TestNewAPIDB_Valid(t *testing.T) {
 	)
 
 	if err != nil {
-		t.Errorf("NewAPIDB() unexpected error \"%v\"", err)
+		t.Fatalf("NewAPIDB() unexpected error \"%v\"", err)
 	}
 
 	if db == nil {
 		t.Fatalf("NewAPIDB() db unexpectedly nil")
-
-		// this is required currently to make the staticcheck linter
-		return
 	}
 
 	if !reflect.DeepEqual(db.BaseURL, u) {

--- a/pkg/database/dir_test.go
+++ b/pkg/database/dir_test.go
@@ -25,7 +25,7 @@ func TestNewDirDB(t *testing.T) {
 	db, err := database.NewDirDB(database.Config{URL: "file:/testdata/db"}, false)
 
 	if err != nil {
-		t.Errorf("unexpected error \"%v\"", err)
+		t.Fatalf("unexpected error \"%v\"", err)
 	}
 
 	expectDBToHaveOSVs(t, db, osvs)
@@ -85,7 +85,7 @@ func TestNewDirDB_WorkingDirectory(t *testing.T) {
 	db, err := database.NewDirDB(database.Config{URL: "file:/testdata/db", WorkingDirectory: "nested-1"}, false)
 
 	if err != nil {
-		t.Errorf("unexpected error \"%v\"", err)
+		t.Fatalf("unexpected error \"%v\"", err)
 	}
 
 	expectDBToHaveOSVs(t, db, osvs)

--- a/pkg/database/zip_test.go
+++ b/pkg/database/zip_test.go
@@ -75,7 +75,7 @@ func cacheWrite(t *testing.T, cache database.Cache) {
 	}
 
 	if err != nil {
-		t.Errorf("unexpected error with cache: %v", err)
+		t.Fatalf("unexpected error with cache: %v", err)
 	}
 }
 
@@ -86,7 +86,7 @@ func cacheWriteBad(t *testing.T, url string, contents string) {
 	err := os.WriteFile(cachePath(url), []byte(contents), 0644)
 
 	if err != nil {
-		t.Errorf("unexpected error with cache: %v", err)
+		t.Fatalf("unexpected error with cache: %v", err)
 	}
 }
 
@@ -179,7 +179,7 @@ func TestNewZippedDB_Offline_WithCache(t *testing.T) {
 	db, err := database.NewZippedDB(database.Config{URL: ts.URL}, true)
 
 	if err != nil {
-		t.Errorf("unexpected error \"%v\"", err)
+		t.Fatalf("unexpected error \"%v\"", err)
 	}
 
 	if db.UpdatedAt != date {
@@ -237,7 +237,7 @@ func TestNewZippedDB_Online_WithoutCache(t *testing.T) {
 	db, err := database.NewZippedDB(database.Config{URL: ts.URL}, false)
 
 	if err != nil {
-		t.Errorf("unexpected error \"%v\"", err)
+		t.Fatalf("unexpected error \"%v\"", err)
 	}
 
 	expectDBToHaveOSVs(t, db, osvs)
@@ -399,7 +399,7 @@ func TestNewZippedDB_FileChecks(t *testing.T) {
 	db, err := database.NewZippedDB(database.Config{URL: ts.URL}, false)
 
 	if err != nil {
-		t.Errorf("unexpected error \"%v\"", err)
+		t.Fatalf("unexpected error \"%v\"", err)
 	}
 
 	expectDBToHaveOSVs(t, db, osvs)
@@ -421,7 +421,7 @@ func TestNewZippedDB_WorkingDirectory(t *testing.T) {
 	db, err := database.NewZippedDB(database.Config{URL: ts.URL, WorkingDirectory: "reviewed"}, false)
 
 	if err != nil {
-		t.Errorf("unexpected error \"%v\"", err)
+		t.Fatalf("unexpected error \"%v\"", err)
 	}
 
 	expectDBToHaveOSVs(t, db, osvs)


### PR DESCRIPTION
For most if not all of these getting an unexpected error will mean the other value is `nil` resulting in a confusing pointer dereference error