### PR TITLE
chore: disable `warpcheck`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,6 +21,7 @@ linters:
     - nonamedreturns  # they have their uses
     - tagliatelle     # we're parsing data from external sources
     - varnamelen      # maybe later
+    - wrapcheck       # not (yet) convinced
     - wsl             # disagree with, for now
     - wsl_v5          # disagree with, for now
   settings:


### PR DESCRIPTION
This linter has required a lot of extra work, and often results in `err123` being triggered about wanting a static error, and I'm not actually convinced this is super useful so let's just disable it for now