### PR TITLE
ci: have `osv-scalibr` updates be done in a dedicated pull request

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,8 +12,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["major"],
-      "groupName": "Major Updates",
-      "enabled": true
+      "groupName": "Major Updates"
     },
     {
       "matchCategories": ["golang"],
@@ -24,8 +23,8 @@
       "groupName": "workflows"
     },
     {
-      "matchDepTypes": ["golang"],
-      "enabled": false
+      "matchPackageNames": ["github.com/google/osv-scalibr"],
+      "groupName": "osv-scalibr"
     }
   ],
   "ignorePaths": ["**/testdata/**"]


### PR DESCRIPTION
This is based on the configuration we're using in `osv-scanner` which has `osv-scalibr` updated in its own pull request