### PR TITLE
test: use `errors.Is` to check for `os.ErrNotExist` in lockfile cases

### DIFF
--- a/pkg/lockfile/parse-bun-lock_test.go
+++ b/pkg/lockfile/parse-bun-lock_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseBunLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseBunLock("testdata/bun/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-cargo-lock_test.go
+++ b/pkg/lockfile/parse-cargo-lock_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseCargoLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseCargoLock("testdata/cargo/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-composer-lock_test.go
+++ b/pkg/lockfile/parse-composer-lock_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseComposerLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseComposerLock("testdata/composer/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-gemfile-lock_test.go
+++ b/pkg/lockfile/parse-gemfile-lock_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseGemfileLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseGemfileLock("testdata/bundler/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseGoLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseGoLock("testdata/go/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-gradle-lock_test.go
+++ b/pkg/lockfile/parse-gradle-lock_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseGradleLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseGradleLock("testdata/gradle/does-not-exist")
 
-	expectErrContaining(t, err, "could not open")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseMavenLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseMavenLock("testdata/maven/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-mix-lock_test.go
+++ b/pkg/lockfile/parse-mix-lock_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseMixLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseMixLock("testdata/mix/does-not-exist")
 
-	expectErrContaining(t, err, "could not open")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/parse-npm-lock-v1_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseNpmLock_v1_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseNpmLock("testdata/npm/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/parse-npm-lock-v2_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseNpmLock_v2_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseNpmLock("testdata/npm/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-nuget-lock-v1_test.go
+++ b/pkg/lockfile/parse-nuget-lock-v1_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseNuGetLock_v1_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseNuGetLock("testdata/nuget/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-pdm-lock_test.go
+++ b/pkg/lockfile/parse-pdm-lock_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -18,7 +20,9 @@ func TestParsePdmLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParsePdmLock("testdata/pdm/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-pipenv-lock_test.go
+++ b/pkg/lockfile/parse-pipenv-lock_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParsePipenvLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParsePipenvLock("testdata/pipenv/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-pnpm-lock_test.go
+++ b/pkg/lockfile/parse-pnpm-lock_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParsePnpmLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParsePnpmLock("testdata/pnpm/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-poetry-lock_test.go
+++ b/pkg/lockfile/parse-poetry-lock_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParsePoetryLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParsePoetryLock("testdata/poetry/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-pubspec-lock_test.go
+++ b/pkg/lockfile/parse-pubspec-lock_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParsePubspecLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParsePubspecLock("testdata/pub/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-renv-lock_test.go
+++ b/pkg/lockfile/parse-renv-lock_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseRenvLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseRenvLock("testdata/renv/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-requirements-txt_test.go
+++ b/pkg/lockfile/parse-requirements-txt_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseRequirementsTxt_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseRequirementsTxt("testdata/pip/does-not-exist")
 
-	expectErrContaining(t, err, "could not open")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-uv-lock_test.go
+++ b/pkg/lockfile/parse-uv-lock_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseUvLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseUvLock("testdata/uv/does-not-exist")
 
-	expectErrContaining(t, err, "could not read")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-yarn-lock-v1_test.go
+++ b/pkg/lockfile/parse-yarn-lock-v1_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseYarnLock_v1_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseYarnLock("testdata/yarn/does-not-exist")
 
-	expectErrContaining(t, err, "could not open")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-yarn-lock-v2_test.go
+++ b/pkg/lockfile/parse-yarn-lock-v2_test.go
@@ -1,6 +1,8 @@
 package lockfile_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/g-rath/osv-detector/pkg/lockfile"
@@ -11,7 +13,9 @@ func TestParseYarnLock_v2_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseYarnLock("testdata/yarn/does-not-exist")
 
-	expectErrContaining(t, err, "could not open")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected \"%v\" error but got \"%v\"", os.ErrNotExist, err)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 


### PR DESCRIPTION
This should be a bit more robust than comparing the actual message