### PR TITLE
perf: skip advisories that are for unrelated packages when loading databases

### DIFF
--- a/main.go
+++ b/main.go
@@ -186,6 +186,7 @@ func loadDatabases(
 	listPackages bool,
 	offline bool,
 	batchSize int,
+	pkgNames []string,
 ) (OSVDatabases, bool) {
 	dbs := make(OSVDatabases, 0, len(dbConfigs))
 
@@ -202,7 +203,7 @@ func loadDatabases(
 	for _, dbConfig := range dbConfigs {
 		r.PrintTextf("  %s", dbConfig.Name)
 
-		db, err := database.Load(dbConfig, offline, batchSize)
+		db, err := database.Load(dbConfig, offline, batchSize, pkgNames)
 
 		if err != nil {
 			r.PrintDatabaseLoadErr(err)
@@ -591,12 +592,20 @@ This flag can be passed multiple times to ignore different vulnerabilities`)
 
 	files.adjustExtraDatabases(*noConfigDatabases, *useAPI, *useDatabases)
 
+	var allPackages []string
+	for _, p := range files {
+		for _, pkg := range p.lockf.Packages {
+			allPackages = append(allPackages, pkg.Name)
+		}
+	}
+
 	dbs, errored := loadDatabases(
 		r,
 		uniqueDBConfigs(files.getConfigs()),
 		*listPackages,
 		*offline,
 		*batchSize,
+		allPackages,
 	)
 
 	if errored {

--- a/pkg/database/config.go
+++ b/pkg/database/config.go
@@ -27,14 +27,14 @@ func (dbc Config) Identifier() string {
 var ErrUnsupportedDatabaseType = errors.New("unsupported database source type")
 
 // Load initializes a new OSV database based on the given Config
-func Load(config Config, offline bool, batchSize int) (DB, error) {
+func Load(config Config, offline bool, batchSize int, pkgNames []string) (DB, error) {
 	switch config.Type {
 	case "zip":
-		return NewZippedDB(config, offline)
+		return NewZippedDB(config, offline, pkgNames)
 	case "api":
 		return NewAPIDB(config, offline, batchSize)
 	case "dir":
-		return NewDirDB(config, offline)
+		return NewDirDB(config, offline, pkgNames)
 	}
 
 	return nil, fmt.Errorf("%w %s", ErrUnsupportedDatabaseType, config.Type)

--- a/pkg/database/dir.go
+++ b/pkg/database/dir.go
@@ -28,7 +28,7 @@ var ErrDirPathWrongProtocol = errors.New("directory path must start with \"file:
 
 // load walks the filesystem starting with the working directory within the local path,
 // loading all OSVs found along the way.
-func (db *DirDB) load() error {
+func (db *DirDB) load(pkgNames []string) error {
 	db.vulnerabilities = make(map[string][]OSV)
 
 	if !strings.HasPrefix(db.LocalPath, "file:") {
@@ -78,7 +78,7 @@ func (db *DirDB) load() error {
 			return nil
 		}
 
-		db.addVulnerability(pa)
+		db.addVulnerability(pa, pkgNames)
 
 		return nil
 	})
@@ -94,7 +94,7 @@ func (db *DirDB) load() error {
 	return nil
 }
 
-func NewDirDB(config Config, offline bool) (*DirDB, error) {
+func NewDirDB(config Config, offline bool, pkgNames []string) (*DirDB, error) {
 	db := &DirDB{
 		name:             config.Name,
 		identifier:       config.Identifier(),
@@ -102,7 +102,7 @@ func NewDirDB(config Config, offline bool) (*DirDB, error) {
 		WorkingDirectory: config.WorkingDirectory,
 		Offline:          offline,
 	}
-	if err := db.load(); err != nil {
+	if err := db.load(pkgNames); err != nil {
 		return nil, fmt.Errorf("unable to load OSV database: %w", err)
 	}
 

--- a/pkg/database/load_test.go
+++ b/pkg/database/load_test.go
@@ -17,7 +17,7 @@ func TestLoad(t *testing.T) {
 	}
 
 	for _, typ := range types {
-		_, err := database.Load(database.Config{Type: typ}, false, 100)
+		_, err := database.Load(database.Config{Type: typ}, false, 100, nil)
 
 		if err == nil {
 			t.Fatalf("NewDirDB() did not return expected error")
@@ -28,7 +28,7 @@ func TestLoad(t *testing.T) {
 func TestLoad_BadType(t *testing.T) {
 	t.Parallel()
 
-	db, err := database.Load(database.Config{Type: "file"}, false, 100)
+	db, err := database.Load(database.Config{Type: "file"}, false, 100, nil)
 
 	if err == nil {
 		t.Fatalf("NewDirDB() did not return expected error")

--- a/pkg/database/mem-check.go
+++ b/pkg/database/mem-check.go
@@ -11,8 +11,14 @@ type memDB struct {
 	VulnerabilitiesCount int
 }
 
-func (db *memDB) addVulnerability(osv OSV) {
+func (db *memDB) addVulnerability(osv OSV, pkgNames []string) {
 	db.VulnerabilitiesCount++
+
+	// if we have been provided a list of package names, only load advisories
+	// that might actually affect those packages, rather than all advisories
+	if len(pkgNames) != 0 && !mightAffectPackages(osv, pkgNames) {
+		return
+	}
 
 	for _, affected := range osv.Affected {
 		hash := string(affected.Package.Ecosystem) + "-" + affected.Package.NormalizedName()

--- a/pkg/database/testdata/db/nested-2/osv-3.json
+++ b/pkg/database/testdata/db/nested-2/osv-3.json
@@ -1,0 +1,12 @@
+{
+  "id": "OSV-3",
+  "affected": [
+    {
+      "package": {
+        "name": "mine2",
+        "ecosystem": "PyPi"
+      },
+      "versions": []
+    }
+  ]
+}

--- a/pkg/database/zip.go
+++ b/pkg/database/zip.go
@@ -126,9 +126,21 @@ func (db *ZipDB) fetchZip() ([]byte, error) {
 	return body, nil
 }
 
+func mightAffectPackages(v OSV, names []string) bool {
+	for _, affected := range v.Affected {
+		for _, name := range names {
+			if affected.Package.Name == name {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // Loads the given zip file into the database as an OSV.
 // It is assumed that the file is JSON and in the working directory of the db
-func (db *ZipDB) loadZipFile(zipFile *zip.File) {
+func (db *ZipDB) loadZipFile(zipFile *zip.File, pkgNames []string) {
 	file, err := zipFile.Open()
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Could not read %s: %v\n", zipFile.Name, err)
@@ -152,7 +164,7 @@ func (db *ZipDB) loadZipFile(zipFile *zip.File) {
 		return
 	}
 
-	db.addVulnerability(osv)
+	db.addVulnerability(osv, pkgNames)
 }
 
 // load fetches a zip archive of the OSV database and loads known vulnerabilities
@@ -161,7 +173,7 @@ func (db *ZipDB) loadZipFile(zipFile *zip.File) {
 // Internally, the archive is cached along with the date that it was fetched
 // so that a new version of the archive is only downloaded if it has been
 // modified, per HTTP caching standards.
-func (db *ZipDB) load() error {
+func (db *ZipDB) load(pkgNames []string) error {
 	db.vulnerabilities = make(map[string][]OSV)
 
 	body, err := db.fetchZip()
@@ -185,13 +197,13 @@ func (db *ZipDB) load() error {
 			continue
 		}
 
-		db.loadZipFile(zipFile)
+		db.loadZipFile(zipFile, pkgNames)
 	}
 
 	return nil
 }
 
-func NewZippedDB(config Config, offline bool) (*ZipDB, error) {
+func NewZippedDB(config Config, offline bool, pkgNames []string) (*ZipDB, error) {
 	db := &ZipDB{
 		name:             config.Name,
 		identifier:       config.Identifier(),
@@ -199,7 +211,7 @@ func NewZippedDB(config Config, offline bool) (*ZipDB, error) {
 		WorkingDirectory: config.WorkingDirectory,
 		Offline:          offline,
 	}
-	if err := db.load(); err != nil {
+	if err := db.load(pkgNames); err != nil {
 		return nil, fmt.Errorf("unable to fetch OSV database: %w", err)
 	}
 


### PR DESCRIPTION
Based on https://github.com/google/osv-scanner/pull/2241, this should greatly reduce peak memory usage of the detector and in theory make it faster since there should be less advisories to check, though in practice I don't expect this to be noticeable as it mainly matters for large databases like Ubuntu which we don't support out of the box.

I've implemented this as part of the `memDb` meaning we retain the total count of advisories loaded externally even though internally the number of advisories retained is likely far lower