### PR TITLE
ci(semantic): skip invalid pypi versions when generating

### DIFF
--- a/generators/generate-pypi-versions.py
+++ b/generators/generate-pypi-versions.py
@@ -20,7 +20,12 @@ UNSUPPORTED_COMPARISONS = []
 
 
 def is_unsupported_comparison(line):
-  return line in UNSUPPORTED_COMPARISONS or line.startswith('langchain') or 'gradio' in line
+  # todo: https://github.com/google/osv.dev/issues/5578
+  return (
+    line in UNSUPPORTED_COMPARISONS
+    or line.startswith('langchain')
+    or 'gradio' in line
+  )
 
 
 def uncomment(line):

--- a/generators/generate-pypi-versions.py
+++ b/generators/generate-pypi-versions.py
@@ -20,7 +20,7 @@ UNSUPPORTED_COMPARISONS = []
 
 
 def is_unsupported_comparison(line):
-  return line in UNSUPPORTED_COMPARISONS or line.startswith('langchain')
+  return line in UNSUPPORTED_COMPARISONS or line.startswith('langchain') or 'gradio' in line
 
 
 def uncomment(line):

--- a/generators/generate-pypi-versions.py
+++ b/generators/generate-pypi-versions.py
@@ -20,7 +20,7 @@ UNSUPPORTED_COMPARISONS = []
 
 
 def is_unsupported_comparison(line):
-  return line in UNSUPPORTED_COMPARISONS
+  return line in UNSUPPORTED_COMPARISONS or line.startswith('langchain')
 
 
 def uncomment(line):


### PR DESCRIPTION
See https://github.com/google/osv.dev/issues/5578